### PR TITLE
Drop rows after merge, not before

### DIFF
--- a/fastnda/main.py
+++ b/fastnda/main.py
@@ -9,7 +9,7 @@ import polars as pl
 from fastnda.dicts import dtype_dict
 from fastnda.nda import read_nda, read_nda_metadata
 from fastnda.ndax import read_ndax, read_ndax_metadata
-from fastnda.utils import _generate_cycle_number, state_dict
+from fastnda.utils import _drop_empty_rows, _generate_cycle_number, state_dict
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,9 @@ def read(
     if "unix_time_s" in df.columns:
         cols += [pl.from_epoch(pl.col("unix_time_s"), time_unit="s").alias("timestamp")]
     df = df.with_columns(cols)
+
+    # Drop empty voltage/current rows
+    df = _drop_empty_rows(df)
 
     # Ensure columns have correct data types
     df = df.with_columns([pl.col(name).cast(dtype_dict[name]) for name in df.columns if name in dtype_dict])

--- a/fastnda/ndax.py
+++ b/fastnda/ndax.py
@@ -806,9 +806,8 @@ def _bytes_to_df(
         arr = arr[arr["step_index"] != 0]
         return pl.DataFrame(arr)
 
-    # If data file, remove 0.0 voltage rows and add Index column
+    # If data file, add Index column (drop empty rows at the end)
     if "voltage_V" in arr.dtype.names:
-        arr = arr[arr["voltage_V"] != 0]
         return pl.DataFrame(arr).with_columns(
             [
                 pl.int_range(1, pl.len() + 1, dtype=pl.Int32).alias("index"),

--- a/fastnda/utils.py
+++ b/fastnda/utils.py
@@ -65,3 +65,10 @@ def _id_first_state(df: pl.DataFrame) -> Literal["chg", "dchg"]:
     if not filtered.is_empty() and filtered[0, "status"] in charge_keys:
         return "chg"
     return "dchg"
+
+
+def _drop_empty_rows(df: pl.DataFrame) -> pl.DataFrame:
+    """Drop rows with zero voltage and current."""
+    return df.remove(
+        (pl.col("voltage_V") == 0) & (pl.col("current_mA") == 0),
+    )


### PR DESCRIPTION
Seems like, rarely, a datapoint can be dropped

Before, empty rows were dropped then an index assigned. May cause issues merging dataframes afterwards.

This PR changes it so empty rows are dropped after the index is assigned and dataframes merged.

See discussion in https://github.com/d-cogswell/NewareNDA/issues/32