### PR TITLE
Fix Cycle typo

### DIFF
--- a/fastnda/dicts.py
+++ b/fastnda/dicts.py
@@ -8,7 +8,7 @@ state_dict = {
     2: "CC_DChg",
     3: "CV_Chg",
     4: "Rest",
-    5: "cycle_count",
+    5: "Cycle",
     7: "CCCV_Chg",
     8: "CP_DChg",
     9: "CP_Chg",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ class TestUtils:
         #     2: "CC_DChg",
         #     3: "CV_Chg",
         #     4: "Rest",
-        #     5: "cycle_count",
+        #     5: "Cycle",
         #     7: "CCCV_Chg",
         #     8: "CP_DChg",
         #     9: "CP_Chg",


### PR DESCRIPTION
Mistakenly got find-replaced
Doesn't actually appear in datafiles so was not caught in tests But still needed for reference