### PR TITLE
Go slightly faster

### DIFF
--- a/fastnda/nda.py
+++ b/fastnda/nda.py
@@ -146,7 +146,7 @@ def _mask_arr(
     """Get polars dataframe from array."""
     assert dtype.names is not None  # noqa: S101
     dtype_no_pad = dtype[[name for name in dtype.names if not name.startswith("_")]]
-    arr = arr.view(dtype_no_pad).flatten()
+    arr = arr.view(dtype_no_pad).ravel()
     return pl.DataFrame(arr).filter(pl.col("identifier") == mask).drop("identifier")
 
 

--- a/fastnda/ndax.py
+++ b/fastnda/ndax.py
@@ -770,35 +770,34 @@ def _bytes_to_df(
     """
     # Read entire file into 1 byte array nrecords x record_size
     num_records = len(buf) // record_size - file_header_records
-    arr = np.frombuffer(buf[record_size * file_header_records :], dtype=np.uint8).reshape((num_records, record_size))
+    arr = np.frombuffer(
+        buf,
+        dtype=np.uint8,
+        offset=record_size * file_header_records,
+    ).reshape((num_records, record_size))
     rows_per_record = (record_size - data_start_ind - record_end_pad) // dtype.itemsize
 
-    # Slice and unpack the bitmask
     if use_bitmask:
         bitmask_start = 4
         bits_in_bitmask = int(np.ceil(rows_per_record / 8))
         bitmask = arr[:, bitmask_start : bitmask_start + bits_in_bitmask]
-        bitmask = np.unpackbits(bitmask, bitorder="little", axis=1).astype(bool)[:, :rows_per_record].flatten()
-
-    # Slice the data
-    data_end_ind = data_start_ind + dtype.itemsize * rows_per_record
-    arr = arr[:, data_start_ind:data_end_ind]
+        bitmask = np.unpackbits(bitmask, bitorder="little", axis=1)[:, :rows_per_record].ravel()
 
     # Remove padding columns
     useful_cols = [name for name in dtype.names if not name.startswith("_")]
     dtype_no_pad = dtype[useful_cols]
-    arr = arr.view(dtype=dtype_no_pad)
 
-    # Flatten
-    arr = arr.flatten()
+    # Slice the data
+    data_end_ind = data_start_ind + dtype.itemsize * rows_per_record
+    data = np.ascontiguousarray(arr[:, data_start_ind:data_end_ind]).view(dtype_no_pad).ravel()
 
-    if not use_bitmask:  # It should have an index column, filter where 0
-        return pl.DataFrame(arr).filter(pl.col("index") != 0)
+    df = pl.DataFrame(data)
 
-    df = pl.DataFrame(arr)
+    if not use_bitmask:
+        return df.filter(pl.col("index") != 0)
     if add_index:
         df = df.with_columns(pl.int_range(1, pl.len() + 1, dtype=pl.Int32).alias("index"))
-    return df.filter(bitmask)
+    return df.filter(pl.Series(bitmask).ne(0))
 
 
 # Map NDC (version, filetype) to handler functions

--- a/fastnda/ndax.py
+++ b/fastnda/ndax.py
@@ -25,8 +25,9 @@ try:
 
     zlib.decompress = isal_zlib.decompress
     zlib.decompressobj = isal_zlib.decompressobj
+    ISAL_AVAILABLE = True
 except ImportError:
-    pass
+    ISAL_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 

--- a/fastnda/ndax.py
+++ b/fastnda/ndax.py
@@ -18,6 +18,16 @@ from fastnda.dicts import (
 )
 from fastnda.utils import _count_changes
 
+try:
+    import zlib
+
+    from isal import isal_zlib
+
+    zlib.decompress = isal_zlib.decompress
+    zlib.decompressobj = isal_zlib.decompressobj
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 description = "Read Neware nda and ndax files fast."
 dependencies = [
     "defusedxml>=0.7.1",
+    "isal; platform_machine == 'x86_64' or platform_machine == 'AMD64' or platform_machine == 'aarch64'",
     "numpy>=2.2.6",
     "polars>=1.33.1",
     "tqdm>=4.67.1",

--- a/tests/test_no_isal.py
+++ b/tests/test_no_isal.py
@@ -1,0 +1,37 @@
+"""Tests ndax reading without isal dependency."""
+
+import builtins
+import sys
+from pathlib import Path
+
+import pytest
+
+import fastnda
+
+
+@pytest.fixture
+def no_isal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate isal not installed."""
+    del_modules = ["isal"]
+    for module in del_modules:
+        if module in sys.modules:
+            monkeypatch.delitem(sys.modules, module)
+
+    original_import = builtins.__import__
+
+    def _fake_import(module: str, *args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        """Intercept imports."""
+        if module in del_modules:
+            msg = f"No module named '{module}'"
+            raise ModuleNotFoundError(msg)
+        return original_import(module, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+
+def test_read_no_isal(no_isal) -> None:  # noqa: ANN001, ARG001
+    """Test reading ndax files without isal, using zlib from stdlib."""
+    with pytest.raises(ModuleNotFoundError):
+        import isal  # noqa: F401, PLC0415
+    test_file = Path(__file__).parent / "test_data" / "nw4-120-1-6-53.ndax"
+    fastnda.read(test_file)

--- a/tests/test_no_isal.py
+++ b/tests/test_no_isal.py
@@ -1,8 +1,8 @@
 """Tests ndax reading without isal dependency."""
 
-import builtins
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -10,28 +10,33 @@ import fastnda
 
 
 @pytest.fixture
-def no_isal(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Simulate isal not installed."""
-    del_modules = ["isal"]
-    for module in del_modules:
-        if module in sys.modules:
-            monkeypatch.delitem(sys.modules, module)
+def fastnda_no_isal(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Simulate isal not being installed."""
+    # Remove fastnda + isal from cache
+    to_remove = [key for key in sys.modules if key in {"isal", "fastnda"} or key.startswith(("isal.", "fastnda."))]
+    for module in to_remove:
+        sys.modules.pop(module, None)
 
-    original_import = builtins.__import__
+    # Remove isal from sys.modules
+    monkeypatch.setitem(sys.modules, "isal", None)
+    monkeypatch.setitem(sys.modules, "isal.isal_zlib", None)
 
-    def _fake_import(module: str, *args, **kwargs):  # noqa: ANN002, ANN003, ANN202
-        """Intercept imports."""
-        if module in del_modules:
-            msg = f"No module named '{module}'"
-            raise ModuleNotFoundError(msg)
-        return original_import(module, *args, **kwargs)
+    # Fresh import fastnda
+    import fastnda  # noqa: PLC0415
+    import fastnda.ndax  # noqa: PLC0415
 
-    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    return fastnda
 
 
-def test_read_no_isal(no_isal) -> None:  # noqa: ANN001, ARG001
-    """Test reading ndax files without isal, using zlib from stdlib."""
-    with pytest.raises(ModuleNotFoundError):
-        import isal  # noqa: F401, PLC0415
+def test_ndax_with_isal() -> None:
+    """Test isal dependency works is being used."""
     test_file = Path(__file__).parent / "test_data" / "nw4-120-1-6-53.ndax"
     fastnda.read(test_file)
+    assert fastnda.ndax.ISAL_AVAILABLE
+
+
+def test_ndax_no_isal(fastnda_no_isal: ModuleType) -> None:
+    """Test importing and reading file without isal dependency."""
+    test_file = Path(__file__).parent / "test_data" / "nw4-120-1-6-53.ndax"
+    fastnda_no_isal.read(test_file)
+    assert not fastnda_no_isal.ndax.ISAL_AVAILABLE


### PR DESCRIPTION
Small optimisations reducing the number of copies in reading bytes

Reading ndc bytes ~25% faster
Reading nda bytes ~15% faster

Adds isal dependency for appropriate platforms - provides ~25% faster decompression in my tests
Falls back on stdlib zlib if isal is not available/not installed

About 10% faster overall, reading 52 different data files 200 MB total 4 s -> 3.6 s