### PR TITLE
Improve CLI/ndax performance

### DIFF
--- a/fastnda/cli.py
+++ b/fastnda/cli.py
@@ -7,9 +7,6 @@ from typing import Annotated, Literal, cast, get_args
 from zipfile import BadZipFile
 
 import typer
-from tqdm import tqdm
-
-import fastnda
 
 LOGGER = logging.getLogger(__name__)
 
@@ -97,15 +94,6 @@ def _require_tables() -> None:
         raise RuntimeError(msg) from e
 
 
-class TqdmHandler(logging.Handler):
-    """Class to handle logs while using tqdm progress bar."""
-
-    def emit(self, record: logging.LogRecord) -> None:
-        """Write log to console."""
-        msg = self.format(record)
-        tqdm.write(msg)
-
-
 @app.callback()
 def main(
     ctx: typer.Context,
@@ -128,10 +116,6 @@ def main(
     root.setLevel(log_level)
     root.handlers.clear()
     ctx.obj = {"verbosity": verbosity}
-
-    handler = TqdmHandler()
-    handler.setFormatter(logging.Formatter("%(name)s:%(levelname)s: %(message)s"))
-    root.addHandler(handler)
 
 
 @app.command()
@@ -206,6 +190,20 @@ def batch_convert(
         raw_categories: Return `step_type` column as integer codes.
 
     """
+    from tqdm import tqdm  # noqa: PLC0415
+
+    class TqdmHandler(logging.Handler):
+        """Class to handle logs while using tqdm progress bar."""
+
+        def emit(self, record: logging.LogRecord) -> None:
+            """Write log to console."""
+            msg = self.format(record)
+            tqdm.write(msg)
+
+    handler = TqdmHandler()
+    handler.setFormatter(logging.Formatter("%(name)s:%(levelname)s: %(message)s"))
+    root = logging.getLogger()
+    root.addHandler(handler)
     if file_format in {"h5", "hdf5"}:
         _require_pandas()
         _require_tables()
@@ -262,7 +260,9 @@ def _convert_with_type(
     pandas: bool,
     raw_categories: bool,
 ) -> None:
-    df = fastnda.read(
+    from fastnda.main import read
+
+    df = read(
         in_file,
         cycle_mode=cycle_mode,
         columns=columns,
@@ -289,7 +289,9 @@ def _convert_with_type(
 @app.command()
 def print_metadata(in_file: InFileArgument, indent: int | None = 4) -> None:
     """Print file metadata to terminal."""
-    typer.echo(json.dumps(fastnda.read_metadata(in_file), indent=indent))
+    from fastnda.main import read_metadata
+
+    typer.echo(json.dumps(read_metadata(in_file), indent=indent))
 
 
 @app.command()
@@ -299,7 +301,13 @@ def convert_metadata(
     indent: int | None = 4,
 ) -> None:
     """Convert .nda / .ndax metadata to json."""
+    from fastnda.main import read_metadata
+
     if out_file is None:
         out_file = in_file.with_suffix(".json")
     with out_file.open("w") as f:
-        json.dump(fastnda.read_metadata(in_file), f, indent=indent)
+        json.dump(read_metadata(in_file), f, indent=indent)
+
+
+if __name__ == "__main__":
+    app()

--- a/fastnda/main.py
+++ b/fastnda/main.py
@@ -7,10 +7,6 @@ from typing import Literal, cast
 import polars as pl
 
 from fastnda.dicts import DTYPE_MAP, STEP_TYPE_MAP
-from fastnda.formats import to_bdf
-from fastnda.nda import read_nda, read_nda_metadata
-from fastnda.ndax import read_ndax, read_ndax_metadata
-from fastnda.utils import _generate_cycle_number
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +39,12 @@ def read(
     # Read file and generate DataFrame
     file = Path(file)
     if file.suffix == ".nda":
+        from fastnda.nda import read_nda
+
         df = read_nda(file)
     elif file.suffix == ".ndax":
+        from fastnda.ndax import read_ndax
+
         df = read_ndax(file)
     else:
         msg = "File type not supported!"
@@ -56,6 +56,8 @@ def read(
         cycle_mode = "auto"
     if cycle_mode in {"chg", "dchg", "auto"}:
         cycle_mode = cast("Literal['chg', 'dchg', 'auto']", cycle_mode)
+        from fastnda.utils import _generate_cycle_number
+
         df = _generate_cycle_number(df, cycle_mode)
 
     if "total_time_s" not in df.columns:
@@ -98,6 +100,8 @@ def read(
     df = df.select(non_aux_columns + aux_columns)
 
     if columns == "bdf":
+        from fastnda.formats import to_bdf
+
         return to_bdf(df)
     return df
 
@@ -114,8 +118,12 @@ def read_metadata(file: str | Path) -> dict[str, str | float]:
     """
     file = Path(file)
     if file.suffix == ".nda":
+        from fastnda.nda import read_nda_metadata
+
         return read_nda_metadata(file)
     if file.suffix == ".ndax":
+        from fastnda.ndax import read_ndax_metadata
+
         return read_ndax_metadata(file)
     msg = "File type not supported!"
     raise ValueError(msg)

--- a/fastnda/main.py
+++ b/fastnda/main.py
@@ -1,12 +1,13 @@
 """Main module for reading Neware NDA and NDAX files."""
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
-import polars as pl
-
-from fastnda.dicts import DTYPE_MAP, STEP_TYPE_MAP
+if TYPE_CHECKING:
+    import polars as pl
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,8 @@ def read(
         from fastnda.utils import _generate_cycle_number
 
         df = _generate_cycle_number(df, cycle_mode)
+    import polars as pl
+    from fastnda.dicts import DTYPE_MAP, STEP_TYPE_MAP
 
     if "total_time_s" not in df.columns:
         max_df = (

--- a/fastnda/ndax.py
+++ b/fastnda/ndax.py
@@ -80,7 +80,10 @@ def read_ndax(file: str | Path) -> pl.DataFrame:
                 aux_df = aux_df.rename({"?": f"aux{aux_id}_{col}"})
             else:  # Otherwise just append aux ID to column names
                 aux_df = aux_df.rename({col: f"aux{aux_id}_{col}" for col in aux_df.columns if col not in ["index"]})
-            df = df.join(aux_df, how="left", on="index")
+            if len(df) == len(aux_df):
+                df = pl.concat([df, aux_df.drop("index")], how="horizontal")
+            else:
+                df = df.join(aux_df, how="left", on="index")
 
     return df
 

--- a/fastnda/ndax.py
+++ b/fastnda/ndax.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import numpy as np
 import polars as pl
-import xmltodict
 from defusedxml import ElementTree
 
 from fastnda.dicts import (
@@ -88,6 +87,8 @@ def read_ndax(file: str | Path) -> pl.DataFrame:
 
 def read_ndax_metadata(file: str | Path) -> dict[str, str | float]:
     """Read metadata from VersionInfo.xml and Step.xml in a Neware .ndax file."""
+    import xmltodict
+
     metadata = {}
     with zipfile.ZipFile(str(file)) as zf:
         xml_files = [f for f in zf.namelist() if f.endswith(".xml")]

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -12,7 +12,7 @@ from polars.testing import assert_series_equal
 
 import fastnda
 from fastnda.dicts import STEP_TYPE_MAP
-from fastnda.main import _generate_cycle_number
+from fastnda.utils import _generate_cycle_number
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Performance improvements

Better ndax reading performance: when merging aux dfs, use concat horizontal if possible, faster than a join ~13% on big files.

Better CLI performance: make all imports lazier, can skip some imports entirely, e.g. tqdm or xmltodict if just reading one file. Shaves a whopping 20-40 ms.