### PR TITLE
Change bdf capacity, energy cols, add "bdf-pref" cols

### DIFF
--- a/fastnda/cli.py
+++ b/fastnda/cli.py
@@ -49,7 +49,7 @@ PandasOption = Annotated[
     ),
 ]
 ColumnsOption = Annotated[
-    Literal["default", "bdf"],
+    Literal["default", "bdf", "bdf-pref"],
     typer.Option(
         "--columns",
         "-c",
@@ -142,7 +142,14 @@ def convert(
             'raw': Leaves cycles as it is found in the Neware file
         columns: Selects how to format the output columns
             'default': fastnda columns, e.g. 'voltage_V', 'current_mA'
-            'bdf': battery-data-format columns, e.g. 'voltage_volt', 'current_ampere'
+            'bdf': battery-data-format columns 'machine-readable' columns
+                e.g. 'voltage_volt', 'current_ampere'
+                battery-data-format is still in development, these column names
+                may change without a major version bump
+            'bdf-pref': battery-data-format 'preferred label' columns
+                e.g. 'Voltage / V', 'Current / A'
+                battery-data-format is still in development, these column names
+                may change without a major version bump
         pandas: Whether to save in old pandas-safe format
         raw_categories: Return `step_type` column as integer codes.
 
@@ -184,7 +191,14 @@ def batch_convert(
             'raw': Leaves cycles as it is found in the Neware file
         columns: Selects how to format the output columns
             'default': fastnda columns, e.g. 'voltage_V', 'current_mA'
-            'bdf': battery-data-format columns, e.g. 'voltage_volt', 'current_ampere'
+            'bdf': battery-data-format columns 'machine-readable' columns
+                e.g. 'voltage_volt', 'current_ampere'
+                battery-data-format is still in development, these column names
+                may change without a major version bump
+            'bdf-pref': battery-data-format 'preferred label' columns
+                e.g. 'Voltage / V', 'Current / A'
+                battery-data-format is still in development, these column names
+                may change without a major version bump
         recursive: Whether to search recursively in subfolders
         pandas: Whether to save in old pandas-safe format
         raw_categories: Return `step_type` column as integer codes.

--- a/fastnda/formats.py
+++ b/fastnda/formats.py
@@ -30,9 +30,26 @@ BDF_MULTIPLIER_MAP: Mapping[str, float] = MappingProxyType(
     }
 )
 
+BDF_PREF_LABEL_MAP: Mapping[str, str] = MappingProxyType(
+    {
+        "record_index": "Record Index / 1",
+        "voltage_volt": "Voltage / V",
+        "current_ampere": "Current / A",
+        "unix_time_second": "Unix Time / s",
+        "step_time_second": "Step Time / s",
+        "test_time_second": "Test Time / s",
+        "cycle_count": "Cycle Count / 1",
+        "step_count": "Step Count / 1",
+        "step_id": "Step ID",
+        "step_type": "Step Type",
+        "step_net_capacity_ah": "Step Net Capacity / Ah",
+        "step_net_energy_wh": "Step Net Energy / Wh",
+    }
+)
+
 
 def to_bdf(df: pl.DataFrame) -> pl.DataFrame:
-    """Convert fastnda dataframe to bdf."""
+    """Convert fastnda columnds to BDF machine readable columns."""
     df = df.rename(BDF_COL_MAP)
 
     # Dynamically rename any aux columns
@@ -46,3 +63,8 @@ def to_bdf(df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(rename_map)
 
     return df.with_columns(pl.col(k) * v for k, v in BDF_MULTIPLIER_MAP.items())
+
+
+def to_bdf_pref(df: pl.DataFrame) -> pl.DataFrame:
+    """Convert fastnda columnds to BDF preferred label columns."""
+    return to_bdf(df).rename(BDF_PREF_LABEL_MAP)

--- a/fastnda/formats.py
+++ b/fastnda/formats.py
@@ -15,7 +15,7 @@ BDF_COL_MAP: Mapping[str, str] = MappingProxyType(
         "total_time_s": "test_time_second",
         "cycle_count": "cycle_count",
         "step_count": "step_count",
-        "step_index": "step_index",
+        "step_index": "step_id",
         "step_type": "step_type",
         "capacity_mAh": "step_net_capacity_ah",
         "energy_mWh": "step_net_energy_wh",

--- a/fastnda/formats.py
+++ b/fastnda/formats.py
@@ -17,16 +17,16 @@ BDF_COL_MAP: Mapping[str, str] = MappingProxyType(
         "step_count": "step_count",
         "step_index": "step_index",
         "step_type": "step_type",
-        "capacity_mAh": "step_capacity_ah",
-        "energy_mWh": "step_energy_wh",
+        "capacity_mAh": "step_net_capacity_ah",
+        "energy_mWh": "step_net_energy_wh",
     }
 )
 
 BDF_MULTIPLIER_MAP: Mapping[str, float] = MappingProxyType(
     {
         "current_ampere": 1e-3,
-        "step_capacity_ah": 1e-3,
-        "step_energy_wh": 1e-3,
+        "step_net_capacity_ah": 1e-3,
+        "step_net_energy_wh": 1e-3,
     }
 )
 

--- a/fastnda/main.py
+++ b/fastnda/main.py
@@ -31,6 +31,8 @@ def read(
         columns: Selects how to format the output columns
             'default': fastnda columns, e.g. 'voltage_V', 'current_mA'
             'bdf': battery-data-format columns, e.g. 'voltage_volt', 'current_ampere'
+                battery-data-format is still in development, these column names
+                may change without a major version bump
         raw_categories: Return `step_type` column as integer codes.
 
     Returns:

--- a/fastnda/main.py
+++ b/fastnda/main.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 def read(
     file: str | Path,
     cycle_mode: Literal["chg", "dchg", "auto", "raw"] = "chg",
-    columns: Literal["default", "bdf"] = "default",
+    columns: Literal["default", "bdf", "bdf-pref"] = "default",
     *,
     raw_categories: bool = False,
 ) -> pl.DataFrame:
@@ -30,7 +30,12 @@ def read(
             'raw': Leaves cycles as it is found in the Neware file.
         columns: Selects how to format the output columns
             'default': fastnda columns, e.g. 'voltage_V', 'current_mA'
-            'bdf': battery-data-format columns, e.g. 'voltage_volt', 'current_ampere'
+            'bdf': battery-data-format columns 'machine-readable' columns
+                e.g. 'voltage_volt', 'current_ampere'
+                battery-data-format is still in development, these column names
+                may change without a major version bump
+            'bdf-pref': battery-data-format 'preferred label' columns
+                e.g. 'Voltage / V', 'Current / A'
                 battery-data-format is still in development, these column names
                 may change without a major version bump
         raw_categories: Return `step_type` column as integer codes.
@@ -104,10 +109,18 @@ def read(
     aux_columns = [name for name in df.columns if name.startswith("aux")]
     df = df.select(non_aux_columns + aux_columns)
 
+    # Output with desired column-style
+    if columns == "default":
+        return df
     if columns == "bdf":
         from fastnda.formats import to_bdf
 
         return to_bdf(df)
+    if columns == "bdf-pref":
+        from fastnda.formats import to_bdf_pref
+
+        return to_bdf_pref(df)
+    logger.warning("Column type %s not understood, using default.", columns)
     return df
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,3 +74,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 def file_pair(request: pytest.FixtureRequest) -> tuple:
     """Return one file_pair from the request as a fixture."""
     return request.param
+
+
+@pytest.fixture
+def test_file() -> Path:
+    """Return a single .ndax file, for tests that do not need depend on file internals."""
+    return Path(__file__).parent / "test_data" / "nw4-120-1-6-53.ndax"

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -326,7 +326,7 @@ class TestRead:
         assert "test_time_second" in df_bdf.columns
         assert "cycle_count" in df_bdf.columns
         assert "step_count" in df_bdf.columns
-        assert "step_index" in df_bdf.columns
+        assert "step_id" in df_bdf.columns
         assert "step_type" in df_bdf.columns
         assert "step_net_capacity_ah" in df_bdf.columns
         assert "step_net_energy_wh" in df_bdf.columns

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -328,12 +328,12 @@ class TestRead:
         assert "step_count" in df_bdf.columns
         assert "step_index" in df_bdf.columns
         assert "step_type" in df_bdf.columns
-        assert "step_capacity_ah" in df_bdf.columns
-        assert "step_energy_wh" in df_bdf.columns
+        assert "step_net_capacity_ah" in df_bdf.columns
+        assert "step_net_energy_wh" in df_bdf.columns
 
         assert_series_equal(df["current_mA"], df_bdf["current_ampere"] * 1e3, check_names=False)
-        assert_series_equal(df["capacity_mAh"], df_bdf["step_capacity_ah"] * 1e3, check_names=False)
-        assert_series_equal(df["energy_mWh"], df_bdf["step_energy_wh"] * 1e3, check_names=False)
+        assert_series_equal(df["capacity_mAh"], df_bdf["step_net_capacity_ah"] * 1e3, check_names=False)
+        assert_series_equal(df["energy_mWh"], df_bdf["step_net_energy_wh"] * 1e3, check_names=False)
 
         # Checking correct order of magnitude, more precise value checks in other tests
         assert_series_equal(

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 
 import polars as pl
 import pytest
-from polars.testing import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 import fastnda
 from fastnda.dicts import STEP_TYPE_MAP
@@ -39,9 +39,8 @@ REV_STEP_TYPE_MAP = {v: k for k, v in STEP_TYPE_MAP.items()}
 class TestRead:
     """Compared parsed data to reference from BTSDA."""
 
-    def test_generate_cycle_number(self) -> None:
+    def test_generate_cycle_number(self, test_file: Path) -> None:
         """Test generating cycle numbers on just one file."""
-        test_file = Path(__file__).parent / "test_data" / "nw4-120-1-6-53.ndax"
         df1 = fastnda.read(test_file, cycle_mode="raw")
         df2 = fastnda.read(test_file, cycle_mode="chg")
         df1 = df1.with_columns(
@@ -306,7 +305,7 @@ class TestRead:
                 raise ValueError(msg)
 
     def test_bdf(self, parsed_data: tuple, file_pair: tuple[Path, Path]) -> None:
-        """Basic checks for metadata reading."""
+        """Test bdf column conversion."""
         df, df_ref = parsed_data
         test_file = file_pair[0]
         if test_file.suffix == ".zip":
@@ -314,9 +313,9 @@ class TestRead:
                 # unzip file to a temp location and read
                 zip_test.extractall(tmp_dir)
                 test_file = Path(tmp_dir) / test_file.stem
-                df_bdf = fastnda.read(test_file, columns="bdf")
+                df_bdf = fastnda.read(test_file, columns="bdf", cycle_mode="raw")
         else:
-            df_bdf = fastnda.read(test_file, columns="bdf")
+            df_bdf = fastnda.read(test_file, columns="bdf", cycle_mode="raw")
 
         assert "record_index" in df_bdf.columns
         assert "voltage_volt" in df_bdf.columns
@@ -331,7 +330,16 @@ class TestRead:
         assert "step_net_capacity_ah" in df_bdf.columns
         assert "step_net_energy_wh" in df_bdf.columns
 
+        assert_series_equal(df["index"], df_bdf["record_index"], check_names=False)
+        assert_series_equal(df["voltage_V"], df_bdf["voltage_volt"], check_names=False)
         assert_series_equal(df["current_mA"], df_bdf["current_ampere"] * 1e3, check_names=False)
+        assert_series_equal(df["unix_time_s"], df_bdf["unix_time_second"], check_names=False)
+        assert_series_equal(df["step_time_s"], df_bdf["step_time_second"], check_names=False)
+        assert_series_equal(df["total_time_s"], df_bdf["test_time_second"], check_names=False)
+        assert_series_equal(df["cycle_count"], df_bdf["cycle_count"], check_names=False)
+        assert_series_equal(df["step_count"], df_bdf["step_count"], check_names=False)
+        assert_series_equal(df["step_index"], df_bdf["step_id"], check_names=False)
+        assert_series_equal(df["step_type"], df_bdf["step_type"], check_names=False)
         assert_series_equal(df["capacity_mAh"], df_bdf["step_net_capacity_ah"] * 1e3, check_names=False)
         assert_series_equal(df["energy_mWh"], df_bdf["step_net_energy_wh"] * 1e3, check_names=False)
 
@@ -343,3 +351,49 @@ class TestRead:
             check_names=False,
             check_dtypes=False,
         )
+
+    def test_bdf_pref(self, parsed_data: tuple, file_pair: tuple[Path, Path]) -> None:
+        """Test bdf preferred column conversion."""
+        df, df_ref = parsed_data
+        test_file = file_pair[0]
+        if test_file.suffix == ".zip":
+            with TemporaryDirectory() as tmp_dir, ZipFile(test_file, "r") as zip_test:
+                # unzip file to a temp location and read
+                zip_test.extractall(tmp_dir)
+                test_file = Path(tmp_dir) / test_file.stem
+                df_bdf = fastnda.read(test_file, columns="bdf-pref")
+        else:
+            df_bdf = fastnda.read(test_file, columns="bdf-pref")
+
+        assert "Record Index / 1" in df_bdf.columns
+        assert "Voltage / V" in df_bdf.columns
+        assert "Current / A" in df_bdf.columns
+        assert "Unix Time / s" in df_bdf.columns
+        assert "Step Time / s" in df_bdf.columns
+        assert "Test Time / s" in df_bdf.columns
+        assert "Cycle Count / 1" in df_bdf.columns
+        assert "Step Count / 1" in df_bdf.columns
+        assert "Step ID" in df_bdf.columns
+        assert "Step Type" in df_bdf.columns
+        assert "Step Net Capacity / Ah" in df_bdf.columns
+        assert "Step Net Energy / Wh" in df_bdf.columns
+
+        assert_series_equal(df["current_mA"], df_bdf["Current / A"] * 1e3, check_names=False)
+        assert_series_equal(df["capacity_mAh"], df_bdf["Step Net Capacity / Ah"] * 1e3, check_names=False)
+        assert_series_equal(df["energy_mWh"], df_bdf["Step Net Energy / Wh"] * 1e3, check_names=False)
+
+        # Checking correct order of magnitude, more precise value checks in other tests
+        assert_series_equal(
+            df_bdf["Current / A"],
+            df_ref["Current(uA)"] * 1e-6,
+            abs_tol=5e-5,
+            check_names=False,
+            check_dtypes=False,
+        )
+
+    def test_bad_column_input(self, test_file: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Test bad columns input to read."""
+        df1 = fastnda.read(test_file, columns="something-wrong")
+        df2 = fastnda.read(test_file, columns="default")
+        assert_frame_equal(df1, df2)
+        assert "not understood" in caplog.text


### PR DESCRIPTION
⚠️ breaking bugfix if using capacity and energy from columns="bdf"

`step_capacity_ah` -> `step_net_capacity_ah`
`step_energy_wh` -> `step_net_energy_wh`

Battery data format is still 0.1.0, so this aspect of fastnda remains subject to change to match the development of bdf.

BDF deprecated `step_capacity_ah` and `step_energy_wh`
The old cols had conflicting definitions, and were used incorrectly in fastnda

Adds BDF preferred columns as an option, with columns="bdf-pref"