### PR TITLE
Add support for all known nda versions

### DIFF
--- a/fastnda/nda.py
+++ b/fastnda/nda.py
@@ -138,16 +138,35 @@ def _get_arr_from_nda(
     return np.frombuffer(mm[header_idx:end], dtype=np.uint8).reshape((num_records, record_len))
 
 
+def _view_arr(
+    arr: np.ndarray,
+    dtype: np.dtype,
+) -> pl.DataFrame:
+    """Get polars dataframe from array, dropping padding columns."""
+    assert dtype.names is not None  # noqa: S101
+    dtype_no_pad = dtype[[name for name in dtype.names if not name.startswith("_")]]
+    arr = arr.view(dtype_no_pad).ravel()
+    return pl.DataFrame(arr)
+
+
 def _mask_arr(
     arr: np.ndarray,
     dtype: np.dtype,
     mask: int,
 ) -> pl.DataFrame:
-    """Get polars dataframe from array."""
-    assert dtype.names is not None  # noqa: S101
-    dtype_no_pad = dtype[[name for name in dtype.names if not name.startswith("_")]]
-    arr = arr.view(dtype_no_pad).ravel()
-    return pl.DataFrame(arr).filter(pl.col("identifier") == mask).drop("identifier")
+    """Get polars dataframe from array, filtered on an identifier value."""
+    return _view_arr(arr, dtype).filter(pl.col("identifier") == mask).drop("identifier")
+
+
+def _nda_head_main_begin(mm: mmap.mmap, *, pos_offset: int = 32, pos64: bool = False) -> int:
+    """Read the data start offset from the header.
+
+    File versions 1-11, 25, 27, store nBegin, nLen at a fixed offset.
+    File versions 12-29 except 25,27 use a different fixed offset.
+    File versions 129-130 use 64-bit pairs instead.
+    """
+    size = 8 if pos64 else 4
+    return int.from_bytes(mm[pos_offset : pos_offset + size], "little")
 
 
 def _merge_aux(
@@ -178,8 +197,117 @@ def _read_nda(mm: mmap.mmap) -> pl.DataFrame:
     return reader(mm)
 
 
+def _read_nda_1(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 1."""
+    header_idx = _nda_head_main_begin(mm)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=38)
+    dtype = np.dtype(
+        [
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u1"),
+            ("step_type", "<u1"),
+            ("step_time_s", "<u4"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad1", "V8"),  # nIR, iTemp - unpopulated in all files checked
+            ("capacity_mAh", "<i8"),
+        ]
+    )
+    return (
+        _view_arr(arr, dtype)
+        .filter(pl.col("index") != 0)
+        .with_columns(
+            [
+                pl.col("cycle_count") + 1,
+                pl.col("step_time_s").cast(pl.Float32),
+                pl.col("voltage_V").cast(pl.Float32) / 10000,
+                pl.col("current_mA").cast(pl.Float32) / 1000,
+                (pl.col("capacity_mAh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+                _count_changes(pl.col("step_index")).alias("step_count"),
+            ]
+        )
+    )
+
+
+def _read_nda_2(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 2 (deprecated by Neware - unreachable in BTSDA)."""
+    header_idx = _nda_head_main_begin(mm)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=57)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u1"),
+            ("step_type", "<u1"),
+            ("step_time_s", "<u4"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad1", "V8"),  # nIR, iTemp
+            ("capacity_mAh", "<i8"),
+            ("_pad2", "V1"),  # bEng flag
+            ("energy_mWh", "<i8"),
+            ("_pad3", "V1"),  # bLocalTime flag
+            ("unix_time_s", "<u8"),
+        ]
+    )
+    return (
+        _view_arr(arr, dtype)
+        .filter(pl.col("identifier").is_in([0, 85]))
+        .drop("identifier")
+        .with_columns(
+            [
+                pl.col("cycle_count") + 1,
+                pl.col("step_time_s").cast(pl.Float32),
+                pl.col("voltage_V").cast(pl.Float32) / 10000,
+                pl.col("current_mA").cast(pl.Float32) / 1000,
+                (pl.col("capacity_mAh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+                (pl.col("energy_mWh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+                _count_changes(pl.col("step_index")).alias("step_count"),
+            ]
+        )
+    )
+
+
+def _read_nda_3(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 3 (file version 3, 4)."""
+    header_idx = _nda_head_main_begin(mm)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=43)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u1"),
+            ("step_type", "<u1"),
+            ("step_time_s", "<u4"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad1", "V8"),  # nIR, iTemp
+            ("capacity_mAh", "<i8"),
+            ("_pad2", "V4"),  # dwCRC32
+        ]
+    )
+    return (
+        _view_arr(arr, dtype)
+        .filter(pl.col("identifier").is_in([0, 85]))
+        .drop("identifier")
+        .with_columns(
+            [
+                pl.col("cycle_count") + 1,
+                pl.col("step_time_s").cast(pl.Float32),
+                pl.col("voltage_V").cast(pl.Float32) / 10000,
+                pl.col("current_mA").cast(pl.Float32) / 1000,
+                (pl.col("capacity_mAh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+                _count_changes(pl.col("step_index")).alias("step_count"),
+            ]
+        )
+    )
+
+
 def _read_nda_5(mm: mmap.mmap) -> pl.DataFrame:
-    """Read nda version 8."""
+    """Read nda version 5 (file versions 5, 6, 7, 8)."""
     # Identify the beginning of the data section - first byte 255 and index = 1
     arr = _get_arr_from_nda(mm, header=b"\xff\x01\x00\x00\x00", record_len=59)
     dtype = np.dtype(
@@ -211,8 +339,128 @@ def _read_nda_5(mm: mmap.mmap) -> pl.DataFrame:
     )
 
 
+def _read_nda_9(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 9."""
+    header_idx = _nda_head_main_begin(mm)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=60)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("_pad0", "V1"),  # btAuxChlID
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u1"),
+            ("step_type", "<u1"),
+            ("step_time_s", "<u4"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad1", "V8"),  # nIR, iTemp
+            ("capacity_mAh", "<i8"),
+            ("energy_mWh", "<i8"),
+            ("unix_time_s", "<u8"),
+            ("_pad2", "V4"),  # dwCRC32
+        ]
+    )
+    return _mask_arr(arr, dtype, 85).with_columns(
+        [
+            pl.col("cycle_count") + 1,
+            pl.col("step_time_s").cast(pl.Float32),
+            pl.col("voltage_V").cast(pl.Float32) / 10000,
+            pl.col("current_mA").cast(pl.Float32) / 1000,
+            (pl.col("capacity_mAh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+            (pl.col("energy_mWh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+            _count_changes(pl.col("step_index")).alias("step_count"),
+        ]
+    )
+
+
+def _read_nda_10(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 10."""
+    header_idx = _nda_head_main_begin(mm)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=64)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("_pad0", "V1"),  # btAuxChlID
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u1"),
+            ("step_type", "<u1"),
+            ("step_time_s", "<u8"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad1", "V8"),  # nIR, iTemp
+            ("capacity_mAh", "<i8"),
+            ("energy_mWh", "<i8"),
+            ("unix_time_s", "<u8"),
+            ("_pad2", "V4"),  # dwCRC32
+        ]
+    )
+    return _mask_arr(arr, dtype, 85).with_columns(
+        [
+            pl.col("cycle_count") + 1,
+            pl.col("step_time_s").cast(pl.Float32) / 1000,
+            pl.col("voltage_V").cast(pl.Float32) / 10000,
+            pl.col("current_mA").cast(pl.Float32) / 1000,
+            (pl.col("capacity_mAh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+            (pl.col("energy_mWh").cast(pl.Float64) * pl.col("current_mA").sign()) / 3600000,
+            _count_changes(pl.col("step_index")).alias("step_count"),
+        ]
+    )
+
+
+def _read_nda_11(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda struct 11 (file versions 11, 12, 13, 15, 18)."""
+    pos_offset = 32 if int(mm[14]) == 11 else 64
+    header_idx = _nda_head_main_begin(mm, pos_offset=pos_offset)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=69)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("_pad0", "V1"),  # btAuxChlID
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u2"),
+            ("step_type", "<u1"),
+            ("step_time_s", "<u8"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad1", "V8"),  # nIR, iTemp
+            ("capacity_mAh", "<i8"),
+            ("energy_mWh", "<i8"),
+            ("unix_time_s", "<u8"),
+            ("range", "<i4"),
+            ("_pad2", "V4"),  # dwCRC32
+        ]
+    )
+    return (
+        _mask_arr(arr, dtype, 85)
+        .with_columns(
+            [
+                pl.col("cycle_count") + 1,
+                pl.col("step_time_s").cast(pl.Float32) / 1000,
+                pl.col("voltage_V").cast(pl.Float32) / 10000,
+                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _count_changes(pl.col("step_index")).alias("step_count"),
+            ]
+        )
+        .with_columns(
+            [
+                pl.col("current_mA") * pl.col("multiplier"),
+                (
+                    pl.col("capacity_mAh").cast(pl.Float64) * pl.col("multiplier") * pl.col("current_mA").sign() / 3600
+                ).cast(pl.Float32),
+                (
+                    pl.col("energy_mWh").cast(pl.Float64) * pl.col("multiplier") * pl.col("current_mA").sign() / 3600
+                ).cast(pl.Float32),
+            ]
+        )
+        .drop(["multiplier", "range"])
+    )
+
+
 def _read_nda_14(mm: mmap.mmap) -> pl.DataFrame:
-    """Read nda version 22."""
+    """Read nda version 14 (file versions 14, 16, 17, 20, 22, 23, 24)."""
     arr = _get_arr_from_nda(mm, b"\xaa\x00\x01\x00\x00\x00", 86)
     data_dtype = np.dtype(
         [
@@ -252,6 +500,97 @@ def _read_nda_14(mm: mmap.mmap) -> pl.DataFrame:
             [
                 pl.col("current_mA") * pl.col("multiplier"),
                 (pl.col(mult_cols).cast(pl.Float64) * pl.col("multiplier").cast(pl.Float64) / 3600).cast(pl.Float32),
+            ]
+        )
+        .drop(["multiplier", "range"])
+    )
+
+
+def _read_nda_19(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 19."""
+    header_idx = _nda_head_main_begin(mm, pos_offset=64)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=68)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("_pad0", "V3"),  # btSubDevID, btChannelID, btAuxChlID
+            ("_pad0b", "V4"),  # dwTestID
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u2"),
+            ("step_type", "<u1"),
+            ("_pad1", "V1"),  # btWorkType
+            ("_pad2", "V1"),  # btStepChgCount
+            ("_pad3", "V3"),  # btReserved
+            ("step_time_s", "<u4"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad4", "V8"),  # nIR, iTemp
+            ("charge_capacity_mAh", "<i4"),
+            ("discharge_capacity_mAh", "<i4"),
+            ("charge_energy_mWh", "<i4"),
+            ("discharge_energy_mWh", "<i4"),
+            ("unix_time_s", "<u4"),
+            ("_pad5", "V4"),  # dwCRC32
+        ]
+    )
+    mult_cols = ["charge_capacity_mAh", "discharge_capacity_mAh", "charge_energy_mWh", "discharge_energy_mWh"]
+    return _mask_arr(arr, dtype, 85).with_columns(
+        [
+            pl.col("cycle_count") + 1,
+            pl.col("step_time_s").cast(pl.Float32),
+            pl.col("voltage_V").cast(pl.Float32) / 10000,
+            pl.col("current_mA").cast(pl.Float32) / 1000,
+            (pl.col(mult_cols).cast(pl.Float64) / 3600).cast(pl.Float32),
+            _count_changes(pl.col("step_index")).alias("step_count"),
+        ]
+    )
+
+
+def _read_nda_25(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 25 (file versions 25, 27)."""
+    header_idx = _nda_head_main_begin(mm)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=70)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("_pad0", "V1"),  # btAuxChlID
+            ("index", "<u4"),
+            ("cycle_count", "<u4"),
+            ("step_index", "<u2"),
+            ("step_type", "<u1"),
+            ("step_time_s", "<u8"),
+            ("voltage_V", "<i4"),
+            ("current_mA", "<i4"),
+            ("_pad1", "V8"),  # nIR, iTemp
+            ("capacity_mAh", "<i8"),
+            ("energy_mWh", "<i8"),
+            ("unix_time_s", "<u8"),
+            ("range", "<i4"),
+            ("_pad2", "V1"),  # btStepChgCount
+            ("_pad3", "V4"),  # dwCRC32
+        ]
+    )
+    return (
+        _mask_arr(arr, dtype, 85)
+        .with_columns(
+            [
+                pl.col("cycle_count") + 1,
+                pl.col("step_time_s").cast(pl.Float32) / 1000,
+                pl.col("voltage_V").cast(pl.Float32) / 10000,
+                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _count_changes(pl.col("step_index")).alias("step_count"),
+            ]
+        )
+        .with_columns(
+            [
+                pl.col("current_mA") * pl.col("multiplier"),
+                (
+                    pl.col("capacity_mAh").cast(pl.Float64) * pl.col("multiplier") * pl.col("current_mA").sign() / 3600
+                ).cast(pl.Float32),
+                (
+                    pl.col("energy_mWh").cast(pl.Float64) * pl.col("multiplier") * pl.col("current_mA").sign() / 3600
+                ).cast(pl.Float32),
             ]
         )
         .drop(["multiplier", "range"])
@@ -333,6 +672,51 @@ def _read_nda_29(mm: mmap.mmap) -> pl.DataFrame:
         ]
     )
     return _merge_aux(data_df, aux_df)
+
+
+def _read_nda_129(mm: mmap.mmap) -> pl.DataFrame:
+    """Read nda version 129 (deprecated by Neware)."""
+    header_idx = _nda_head_main_begin(mm, pos_offset=82, pos64=True)
+    arr = _get_arr_from_nda(mm, header=header_idx, record_len=88)
+    dtype = np.dtype(
+        [
+            ("identifier", "<u1"),
+            ("_pad0", "V5"),  # btDevType, btDevID, btUnitID, btChlID, btAuxChlIndex
+            ("_pad0b", "V2"),  # wReserve
+            ("_pad0c", "V4"),  # dwTestID
+            ("index", "<u4"),  # dwTestDataSN
+            ("_pad0d", "V4"),  # dwUnitNuid
+            ("step_index", "<u1"),
+            ("step_type", "<u1"),
+            ("_pad1", "V1"),  # btStepChgCount
+            ("_pad2", "V1"),  # btReserve
+            ("_pad3", "V4"),  # stWorkStatus
+            ("step_time_s", "<u4"),  # Time64.dwS
+            ("_pad4", "V4"),  # Time64.dwNS
+            ("voltage_V", "<f4"),
+            ("current_mA", "<f4"),
+            ("_pad5", "V8"),  # fInterRes, fTempture
+            ("charge_capacity_mAh", "<f4"),
+            ("charge_energy_mWh", "<f4"),
+            ("discharge_capacity_mAh", "<f4"),
+            ("discharge_energy_mWh", "<f4"),
+            ("unix_time_s", "<u8"),  # microseconds
+            ("_pad6", "V12"),  # dwCurStepRange, dwLogCode, dwCRC32
+        ]
+    )
+    mult_cols = ["charge_capacity_mAh", "discharge_capacity_mAh", "charge_energy_mWh", "discharge_energy_mWh"]
+    return (
+        _view_arr(arr, dtype)
+        .filter(pl.col("identifier").is_in([0, 85]))
+        .drop("identifier")
+        .with_columns(
+            [
+                pl.col(mult_cols) / 3600,
+                (pl.col("unix_time_s").cast(pl.Float64) / 1e6).alias("unix_time_s"),
+                _count_changes(pl.col("step_index")).alias("step_count"),
+            ]
+        )
+    )
 
 
 def _read_nda_130(mm: mmap.mmap) -> pl.DataFrame:
@@ -440,55 +824,37 @@ def _read_nda_130_90(mm: mmap.mmap) -> pl.DataFrame:
     )
 
 
-# NDA FileVer code -> struct type
-NDA_FILE_TO_STRUCT: dict[int, int] = {
-    1: 1,
-    2: 2,
-    3: 3,
-    4: 3,
-    5: 5,
-    6: 5,
-    7: 5,
-    8: 5,
-    9: 9,
-    10: 10,
-    11: 11,
-    12: 11,
-    13: 11,
-    14: 14,
-    15: 11,
-    16: 14,
-    17: 14,
-    18: 11,
-    19: 19,
-    20: 14,
-    22: 14,
-    23: 14,
-    24: 14,
-    25: 25,
-    26: 29,
-    27: 25,
-    28: 29,
-    29: 29,
-    129: 129,
-    130: 130,  # Variable length
-}
-
-# NDA Struct type -> reader
-NDA_STRUCT_TO_READER: dict[int, None | Callable[[mmap.mmap], pl.DataFrame]] = {
-    1: None,
-    2: None,
-    3: None,
+# NDA FileVer code -> struct type reader
+NDA_READERS: dict[int, Callable[[mmap.mmap], pl.DataFrame]] = {
+    1: _read_nda_1,
+    2: _read_nda_2,  # Deprecated by Neware
+    3: _read_nda_3,
+    4: _read_nda_3,
     5: _read_nda_5,
-    9: None,
-    10: None,
-    11: None,
+    6: _read_nda_5,
+    7: _read_nda_5,
+    8: _read_nda_5,
+    9: _read_nda_9,
+    10: _read_nda_10,
+    11: _read_nda_11,
+    12: _read_nda_11,
+    13: _read_nda_11,
     14: _read_nda_14,
-    19: None,
-    25: None,
+    15: _read_nda_11,
+    16: _read_nda_14,
+    17: _read_nda_14,
+    18: _read_nda_11,
+    19: _read_nda_19,
+    20: _read_nda_14,
+    # 21: Missing in Neware
+    22: _read_nda_14,
+    23: _read_nda_14,
+    24: _read_nda_14,
+    25: _read_nda_25,
+    26: _read_nda_29,
+    27: _read_nda_25,
+    28: _read_nda_29,
     29: _read_nda_29,
-    129: None,
-    130: _read_nda_130,
+    129: _read_nda_129,  # Deprecated by Neware
+    130: _read_nda_130,  # Variable length
 }
-
-NDA_READERS = {k: NDA_STRUCT_TO_READER[v] for k, v in NDA_FILE_TO_STRUCT.items()}

--- a/fastnda/nda.py
+++ b/fastnda/nda.py
@@ -178,7 +178,7 @@ def _read_nda(mm: mmap.mmap) -> pl.DataFrame:
     return reader(mm)
 
 
-def _read_nda_8(mm: mmap.mmap) -> pl.DataFrame:
+def _read_nda_5(mm: mmap.mmap) -> pl.DataFrame:
     """Read nda version 8."""
     # Identify the beginning of the data section - first byte 255 and index = 1
     arr = _get_arr_from_nda(mm, header=b"\xff\x01\x00\x00\x00", record_len=59)
@@ -211,7 +211,7 @@ def _read_nda_8(mm: mmap.mmap) -> pl.DataFrame:
     )
 
 
-def _read_nda_22(mm: mmap.mmap) -> pl.DataFrame:
+def _read_nda_14(mm: mmap.mmap) -> pl.DataFrame:
     """Read nda version 22."""
     arr = _get_arr_from_nda(mm, b"\xaa\x00\x01\x00\x00\x00", 86)
     data_dtype = np.dtype(
@@ -440,11 +440,55 @@ def _read_nda_130_90(mm: mmap.mmap) -> pl.DataFrame:
     )
 
 
-NDA_READERS: dict[int, Callable[[mmap.mmap], pl.DataFrame]] = {
-    8: _read_nda_8,
-    22: _read_nda_22,
-    23: _read_nda_22,
-    26: _read_nda_29,
+# NDA FileVer code -> struct type
+NDA_FILE_TO_STRUCT: dict[int, int] = {
+    1: 1,
+    2: 2,
+    3: 3,
+    4: 3,
+    5: 5,
+    6: 5,
+    7: 5,
+    8: 5,
+    9: 9,
+    10: 10,
+    11: 11,
+    12: 11,
+    13: 11,
+    14: 14,
+    15: 11,
+    16: 14,
+    17: 14,
+    18: 11,
+    19: 19,
+    20: 14,
+    22: 14,
+    23: 14,
+    24: 14,
+    25: 25,
+    26: 29,
+    27: 25,
+    28: 29,
+    29: 29,
+    129: 129,
+    130: 130,  # Variable length
+}
+
+# NDA Struct type -> reader
+NDA_STRUCT_TO_READER: dict[int, None | Callable[[mmap.mmap], pl.DataFrame]] = {
+    1: None,
+    2: None,
+    3: None,
+    5: _read_nda_5,
+    9: None,
+    10: None,
+    11: None,
+    14: _read_nda_14,
+    19: None,
+    25: None,
     29: _read_nda_29,
+    129: None,
     130: _read_nda_130,
 }
+
+NDA_READERS = {k: NDA_STRUCT_TO_READER[v] for k, v in NDA_FILE_TO_STRUCT.items()}

--- a/fastnda/nda.py
+++ b/fastnda/nda.py
@@ -3,6 +3,7 @@
 import logging
 import mmap
 import struct
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 
@@ -13,6 +14,10 @@ from fastnda.dicts import MULTIPLIER_MAP
 from fastnda.utils import _count_changes
 
 logger = logging.getLogger(__name__)
+
+
+class UnverifiedFormatWarning(UserWarning):
+    """Raised when reading an nda_version which hasn't been tested against real data."""
 
 
 def read_nda(file: str | Path) -> pl.DataFrame:
@@ -193,6 +198,14 @@ def _read_nda(mm: mmap.mmap) -> pl.DataFrame:
     if reader is None:
         msg = f"nda version {nda_version} is not yet supported!"
         raise NotImplementedError(msg) from None
+    if nda_version not in _CONFIRMED_NDA_VERSIONS:
+        warnings.warn(
+            f"nda_version {nda_version} has not been verified against real Neware data - results may be "
+            "incorrect. If you can, please share a sample file at "
+            "https://github.com/empaeconversion/fastnda/issues so we can confirm this format.",
+            UnverifiedFormatWarning,
+            stacklevel=2,
+        )
     logger.debug("Reading nda version %d", nda_version)
     return reader(mm)
 
@@ -862,3 +875,9 @@ NDA_READERS: dict[int, Callable[[mmap.mmap], pl.DataFrame]] = {
     129: _read_nda_129,  # Deprecated by Neware
     130: _read_nda_130,  # Variable length
 }
+
+# Reader functions confirmed against real data
+_CONFIRMED_READER_NAMES = frozenset({"_read_nda_5", "_read_nda_14", "_read_nda_29", "_read_nda_130"})
+_CONFIRMED_NDA_VERSIONS = frozenset(
+    version for version, reader in NDA_READERS.items() if reader.__name__ in _CONFIRMED_READER_NAMES
+)

--- a/fastnda/nda.py
+++ b/fastnda/nda.py
@@ -691,8 +691,8 @@ def _read_nda_129(mm: mmap.mmap) -> pl.DataFrame:
             ("_pad1", "V1"),  # btStepChgCount
             ("_pad2", "V1"),  # btReserve
             ("_pad3", "V4"),  # stWorkStatus
-            ("step_time_s", "<u4"),  # Time64.dwS
-            ("_pad4", "V4"),  # Time64.dwNS
+            ("step_time_s", "<u4"),  # Time64.dwS (seconds)
+            ("step_time_ns", "<u4"),  # Time64.dwNS (nanoseconds)
             ("voltage_V", "<f4"),
             ("current_mA", "<f4"),
             ("_pad5", "V8"),  # fInterRes, fTempture
@@ -713,9 +713,13 @@ def _read_nda_129(mm: mmap.mmap) -> pl.DataFrame:
             [
                 pl.col(mult_cols) / 3600,
                 (pl.col("unix_time_s").cast(pl.Float64) / 1e6).alias("unix_time_s"),
+                (pl.col("step_time_s").cast(pl.Float64) + pl.col("step_time_ns") / 1e9)
+                .cast(pl.Float32)
+                .alias("step_time_s"),
                 _count_changes(pl.col("step_index")).alias("step_count"),
             ]
         )
+        .drop("step_time_ns")
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ fix = true
     "PT011", # allow just checking for ValueError without match
 ]
 
+[tool.pytest.ini_options]
+addopts = "-rxX"
+
 [tool.bumpver]
 current_version = "v1.2.0"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ fix = true
 "tests/*.py" = [
     "S101", # asserts allowed in tests
     "PT011", # allow just checking for ValueError without match
+    "SLF001", # unit tests intentionally reach into private _read_nda_x internals
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from fastnda.nda import _read_nda_8, _read_nda_29, read_nda, read_nda_metadata
+from fastnda.nda import _read_nda_5, _read_nda_29, read_nda, read_nda_metadata
 from fastnda.ndax import _read_ndc, _read_ndc_11_filetype_5, _read_ndc_16_filetype_5
 
 
@@ -41,4 +41,4 @@ class TestMissing:
         with pytest.raises(EOFError):
             _read_nda_29(mm)
         with pytest.raises(EOFError):
-            _read_nda_8(mm)
+            _read_nda_5(mm)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,7 +1,9 @@
 """Test read functionality."""
 
+import importlib
 import re
 import warnings
+from collections.abc import Callable, Generator
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
@@ -11,6 +13,7 @@ import pytest
 from polars.testing import assert_frame_equal, assert_series_equal
 
 import fastnda
+import fastnda.nda as _nda_module
 from fastnda.dicts import STEP_TYPE_MAP
 from fastnda.utils import _generate_cycle_number
 
@@ -406,3 +409,45 @@ class TestRead:
         df2 = fastnda.read(test_file, columns="default")
         assert_frame_equal(df1, df2)
         assert "not understood" in caplog.text
+
+
+def _instrument_reader_dict(module_name: str, dict_attr: str) -> Generator[set[str], None, None]:
+    """Wrap every entry of module_name.dict_attr to record which reader functions get called."""
+    module = importlib.import_module(module_name)
+    reader_dict: dict = getattr(module, dict_attr)
+    called: set[str] = set()
+    original = dict(reader_dict)
+    for key, reader in original.items():
+        if reader is None:
+            continue
+        reader_name = reader.__name__
+
+        def wrapper(*args: object, _reader: Callable = reader, _name: str = reader_name) -> object:
+            called.add(_name)
+            return _reader(*args)
+
+        reader_dict[key] = wrapper
+    try:
+        yield called
+    finally:
+        reader_dict.clear()
+        reader_dict.update(original)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def nda_reader_call_tracker() -> Generator[set[str], None, None]:
+    """Track which fastnda.nda reader functions get called by real data in this module."""
+    yield from _instrument_reader_dict("fastnda.nda", "NDA_READERS")
+
+
+_DISTINCT_NDA_READER_NAMES = sorted({r.__name__ for r in _nda_module.NDA_READERS.values() if r is not None})
+
+
+class TestNdaVersionCoverage:
+    """Track which NDA reader functions are tested with real data."""
+
+    @pytest.mark.parametrize("reader_name", _DISTINCT_NDA_READER_NAMES)
+    def test_reader_called_with_real_data(self, reader_name: str, nda_reader_call_tracker: set[str]) -> None:
+        """Confirm this reader function was actually invoked by TestRead's real-data reads."""
+        if reader_name not in nda_reader_call_tracker:
+            pytest.xfail(f"{reader_name} was never tested with a real data file.")

--- a/tests/test_synthetic_nda.py
+++ b/tests/test_synthetic_nda.py
@@ -1,0 +1,1084 @@
+"""Unit tests for fastnda.nda's low-level `_read_nda_x` struct decoders.
+
+Uses minimal synthetic byte buffers matching each struct's known layout and
+calls the reader function directly. Tests logic but does not confirm
+correctness against a real vendor file - readers still XFAIL in
+test_read.py::TestNdaVersionCoverage if they've never been exercised by real
+data.
+
+Several scaling factors (voltage, current, capacity/energy, time, ...) for
+newly-added structs are currently best guesses, not confirmed with real data.
+"""
+
+import mmap
+import struct
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import ClassVar
+
+import polars as pl
+import pytest
+
+from fastnda import nda
+
+# numpy dtype typestr -> struct module format char
+_TYPE_STRUCT = {
+    "<u1": "B",
+    "<u2": "H",
+    "<u4": "I",
+    "<u8": "Q",
+    "<i1": "b",
+    "<i2": "h",
+    "<i4": "i",
+    "<i8": "q",
+    "<f4": "f",
+    "<f8": "d",
+}
+
+
+def _pack_record(layout: list[tuple[str, str]], values: Mapping[str, float | int]) -> bytes:
+    """Pack one record's bytes from a (name, numpy-typestr) layout and a value dict.
+
+    Args:
+        layout: (name, numpy_typestr) pairs of colum name and numpy datatype.
+            Padding entries (typestr like "V8") are zero-filled.
+        values: Field name -> value. Any field in `layout` but missing from
+            `values` defaults to zero.
+
+    Returns:
+        The packed record bytes.
+
+    """
+    chunks = []
+    for name, typestr in layout:
+        if typestr.startswith("V"):
+            chunks.append(b"\x00" * int(typestr[1:]))
+        else:
+            chunks.append(struct.pack("<" + _TYPE_STRUCT[typestr], values.get(name, 0)))
+    return b"".join(chunks)
+
+
+def _build_rows(
+    layout: list[tuple[str, str]],
+    defaults: Mapping[str, float | int],
+    columns: Mapping[str, Sequence[float | int]],
+) -> bytes:
+    """Pack many records from a shared defaults dict and column-oriented values.
+
+    Args:
+        layout: (name, numpy_typestr) pairs, see `_pack_record`.
+        defaults: Field values held constant across every row.
+        columns: Field name -> list of values.
+
+    Returns:
+        Concatenated bytes for every row, in order.
+
+    """
+    lengths = {len(v) for v in columns.values()}
+    assert len(lengths) == 1, f"columns must all have the same length, got {[len(v) for v in columns.values()]}"
+    n_rows = lengths.pop()
+    chunks = []
+    for i in range(n_rows):
+        values = dict(defaults)
+        for name, vals in columns.items():
+            values[name] = vals[i]
+        chunks.append(_pack_record(layout, values))
+    return b"".join(chunks)
+
+
+def _charge_discharge_columns(
+    n_cycles: int,
+    *,
+    charge_current: float,
+    discharge_current: float,
+) -> dict[str, list[int | float]]:
+    """Build charge/discharge columns.
+
+    Helper function for testing larger synthetic datasets.
+
+    Args:
+        n_cycles: Number of charge/discharge cycles to generate (2 rows each).
+        charge_current: current_mA value for every charge (odd) row.
+        discharge_current: current_mA value for every discharge (even) row.
+
+    Returns:
+        Columns for index, step_index, step_type, cycle_count, current_mA.
+        Other fields (voltage, capacity, ...) go in `defaults` passed to
+        `_build_rows` instead.
+
+    """
+    n_rows = 2 * n_cycles
+    return {
+        "index": list(range(1, n_rows + 1)),
+        "step_index": [i for cycle in range(n_cycles) for i in (2 * cycle + 1, 2 * cycle + 2)],
+        "step_type": [1, 2] * n_cycles,
+        "cycle_count": [cycle for cycle in range(n_cycles) for _ in range(2)],
+        "current_mA": [charge_current, discharge_current] * n_cycles,
+    }
+
+
+def _make_mmap(data: bytes) -> mmap.mmap:
+    """Build an anonymous memory-mapped buffer containing exactly `data`.
+
+    Args:
+        data: Bytes to write into the buffer.
+
+    Returns:
+        The memory-mapped buffer.
+
+    """
+    mm = mmap.mmap(-1, len(data))
+    mm[:] = data
+    return mm
+
+
+def _header_offset_preamble(
+    pos_offset: int,
+    main_begin: int,
+    *,
+    pos64: bool = False,
+    version_byte: int | None = None,
+) -> bytes:
+    """Build leading header bytes for a header-offset-based reader.
+
+    Zero-filled up through pos_offset + (8 if pos64 else 4), with `main_begin`
+    encoded as a little-endian uint32/uint64 at pos_offset.
+
+    Args:
+        pos_offset: Byte offset of the position-info field in the header.
+        main_begin: Value to encode there - the data section's start offset.
+        pos64: Encode as a 64-bit pair instead of 32-bit.
+        version_byte: If given, placed at offset 14, since _read_nda_11 reads
+            mm[14] directly to pick which header layout is in play.
+
+    Returns:
+        The header preamble bytes.
+
+    """
+    size = 8 if pos64 else 4
+    buf = bytearray(pos_offset + size)
+    buf[pos_offset : pos_offset + size] = main_begin.to_bytes(size, "little")
+    if version_byte is not None:
+        buf[14] = version_byte
+    return bytes(buf)
+
+
+def _assert_col(df: pl.DataFrame, col: str, expected: list, *, abs_tol: float = 1e-4) -> None:
+    """Assert a column's values match expected, in row order, within tolerance.
+
+    Args:
+        df: DataFrame to check.
+        col: Column name to check.
+        expected: Expected values, in index order.
+        abs_tol: Absolute tolerance used when an expected value is a float.
+
+    """
+    actual = df.sort("index")[col].to_list()
+    assert len(actual) == len(expected), f"{col}: expected {len(expected)} rows, got {len(actual)}: {actual}"
+    for a, e in zip(actual, expected, strict=True):
+        if isinstance(e, float):
+            assert a == pytest.approx(e, abs=abs_tol), f"{col}: {actual} != {expected}"
+        else:
+            assert a == e, f"{col}: {actual} != {expected}"
+
+
+class TestReadNda1:
+    """NdaData1 (file version 1): no identifier byte, header offset 32."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u4"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad1", "V8"),
+        ("capacity_mAh", "<i8"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"cycle_count": 0}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10, 20],
+                "voltage_V": [36000, 35000],
+                "current_mA": [200000, -150000],
+                "capacity_mAh": [1800000, 900000],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=32, main_begin=36)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_1(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "cycle_count", [1, 1])
+        _assert_col(df, "step_index", [1, 2])
+        _assert_col(df, "step_type", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda2:
+    """NdaData2 (file version 2, deprecated by Neware): identifier in {0, 85}, header offset 32."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u4"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad1", "V8"),
+        ("capacity_mAh", "<i8"),
+        ("_pad2", "V1"),
+        ("energy_mWh", "<i8"),
+        ("_pad3", "V1"),
+        ("unix_time_s", "<u8"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"cycle_count": 0}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "identifier": [85, 0],  # exercise the "0 or 85" mask
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10, 20],
+                "voltage_V": [36000, 35000],
+                "current_mA": [200000, -150000],
+                "capacity_mAh": [1800000, 900000],
+                "energy_mWh": [3600000, 1800000],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=32, main_begin=36)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_2(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "cycle_count", [1, 1])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "energy_mWh", [1.0, -0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda3:
+    """NdaData3 (file versions 3, 4): identifier in {0, 85}, header offset 32."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u4"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad1", "V8"),
+        ("capacity_mAh", "<i8"),
+        ("_pad2", "V4"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"cycle_count": 0}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "identifier": [85, 0],
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10, 20],
+                "voltage_V": [36000, 35000],
+                "current_mA": [200000, -150000],
+                "capacity_mAh": [1800000, 900000],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=32, main_begin=36)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_3(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "cycle_count", [1, 1])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda5:
+    """NdaData5 (file versions 5-8): magic-byte header search, mask 0."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u4"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad2", "V8"),
+        ("capacity_mAh", "<i8"),
+        ("energy_mWh", "<i8"),
+        ("unix_time_s", "<u8"),
+        ("_pad3", "V4"),
+    ]
+    # cycle_count is 1-based in raw data
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 0, "cycle_count": 1}
+    SENTINEL: ClassVar[bytes] = b"\xff\x01\x00\x00\x00" + b"\x00" * (59 - 5)
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        # Sentinel record: identifier=255, index=1, rest arbitrary - located by
+        # the magic-byte search, then filtered out since mask=0 excludes it.
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10, 20],
+                "voltage_V": [36000, 35000],
+                "current_mA": [200000, -150000],
+                "capacity_mAh": [1800000, 900000],
+                "energy_mWh": [3600000, 1800000],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        mm = _make_mmap(self.SENTINEL + data)
+
+        df = nda._read_nda_5(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "cycle_count", [1, 1])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "energy_mWh", [1.0, -0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+    def test_step_count_over_many_cycles(self) -> None:
+        """Stress-test step_count's change-detection logic over a much larger row count."""
+        n_cycles = 50
+        columns = _charge_discharge_columns(n_cycles, charge_current=200000, discharge_current=-150000)
+        # Cycle count is 1-based in nda5
+        columns = {**columns, "cycle_count": [c + 1 for c in columns["cycle_count"]]}
+        defaults = {
+            **self.DEFAULTS,
+            "voltage_V": 36000,
+            "capacity_mAh": 1800000,
+            "energy_mWh": 3600000,
+            "step_time_s": 10,
+        }
+        data = _build_rows(self.LAYOUT, defaults, columns=columns)
+        mm = _make_mmap(self.SENTINEL + data)
+
+        df = nda._read_nda_5(mm)
+
+        n_rows = 2 * n_cycles
+        assert len(df) == n_rows
+        _assert_col(df, "index", list(range(1, n_rows + 1)))
+        _assert_col(df, "step_count", list(range(1, n_rows + 1)))
+        _assert_col(df, "cycle_count", [c // 2 + 1 for c in range(n_rows)])
+        _assert_col(df, "current_mA", [200.0, -150.0] * n_cycles)
+
+
+class TestReadNda9:
+    """NdaData9 (file version 9): identifier must be exactly 85, header offset 32."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad0", "V1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u4"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad1", "V8"),
+        ("capacity_mAh", "<i8"),
+        ("energy_mWh", "<i8"),
+        ("unix_time_s", "<u8"),
+        ("_pad2", "V4"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85, "cycle_count": 0}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10, 20],
+                "voltage_V": [36000, 35000],
+                "current_mA": [200000, -150000],
+                "capacity_mAh": [1800000, 900000],
+                "energy_mWh": [3600000, 1800000],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=32, main_begin=36)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_9(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "energy_mWh", [1.0, -0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda10:
+    """NdaData10 (file version 10): step_time_s is u8 in ms (/1000), header offset 32."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad0", "V1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u8"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad1", "V8"),
+        ("capacity_mAh", "<i8"),
+        ("energy_mWh", "<i8"),
+        ("unix_time_s", "<u8"),
+        ("_pad2", "V4"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85, "cycle_count": 0}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10000, 20000],
+                "voltage_V": [36000, 35000],
+                "current_mA": [200000, -150000],
+                "capacity_mAh": [1800000, 900000],
+                "energy_mWh": [3600000, 1800000],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=32, main_begin=36)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_10(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "energy_mWh", [1.0, -0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda11:
+    """NdaData11 (file versions 11, 12, 13, 15, 18): range-based multiplier, signed net capacity/energy.
+
+    Version 11 itself uses header offset 32; versions 12/13/15/18 use offset
+    64 - _read_nda_11 picks between them by reading mm[14] directly, so the
+    main test exercises the version==11 path explicitly.
+    """
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad0", "V1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u2"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u8"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad1", "V8"),
+        ("capacity_mAh", "<i8"),
+        ("energy_mWh", "<i8"),
+        ("unix_time_s", "<u8"),
+        ("range", "<i4"),
+        ("_pad2", "V4"),
+    ]
+    # range=100 -> multiplier 1e-2 (see fastnda.dicts.MULTIPLIER_MAP)
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85, "cycle_count": 0, "range": 100}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10000, 20000],
+                "voltage_V": [36000, 35000],
+                "current_mA": [20000, -15000],
+                "capacity_mAh": [180000, 90000],
+                "energy_mWh": [360000, 180000],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=32, main_begin=36, version_byte=11)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_11(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "energy_mWh", [1.0, -0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+    def test_version_12_uses_offset_64_header(self) -> None:
+        """Versions sharing this struct other than 11 use the unified header at offset 64."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1],
+                "step_index": [1],
+                "step_type": [1],
+                "voltage_V": [36000],
+                "current_mA": [20000],
+                "capacity_mAh": [180000],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=64, main_begin=68, version_byte=12)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_11(mm)
+
+        _assert_col(df, "index", [1])
+        _assert_col(df, "voltage_V", [3.6])
+
+    def test_step_count_over_many_cycles(self) -> None:
+        """Stress-test step_count's change-detection logic over a much larger row count."""
+        n_cycles = 50
+        columns = _charge_discharge_columns(n_cycles, charge_current=20000, discharge_current=-15000)
+        defaults = {
+            **self.DEFAULTS,
+            "voltage_V": 36000,
+            "capacity_mAh": 180000,
+            "energy_mWh": 360000,
+            "step_time_s": 10000,
+        }
+        header = _header_offset_preamble(pos_offset=32, main_begin=36, version_byte=11)
+        data = _build_rows(self.LAYOUT, defaults, columns=columns)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_11(mm)
+
+        n_rows = 2 * n_cycles
+        assert len(df) == n_rows
+        _assert_col(df, "index", list(range(1, n_rows + 1)))
+        _assert_col(df, "step_count", list(range(1, n_rows + 1)))
+        _assert_col(df, "current_mA", [200.0, -150.0] * n_cycles)
+
+
+class TestReadNda14:
+    """NdaData14 (file versions 14, 16, 17, 20, 22, 23, 24): magic-byte header, split charge/discharge."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad1", "V1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u2"),
+        ("step_type", "<u1"),
+        ("step_count", "<u1"),
+        ("step_time_s", "<u8"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad3", "V8"),
+        ("charge_capacity_mAh", "<i8"),
+        ("discharge_capacity_mAh", "<i8"),
+        ("charge_energy_mWh", "<i8"),
+        ("discharge_energy_mWh", "<i8"),
+        ("unix_time_s", "<u8"),
+        ("range", "<i4"),
+        ("_pad5", "V4"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85, "cycle_count": 0, "range": 100}
+    SENTINEL: ClassVar[bytes] = b"\xaa\x00\x01\x00\x00\x00" + b"\x00" * (86 - 6)
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        # Sentinel: identifier=170, index=1, rest arbitrary - filtered out (mask=85).
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10000, 20000],
+                "voltage_V": [36000, 35000],
+                "current_mA": [20000, -15000],
+                "charge_capacity_mAh": [180000, 0],
+                "discharge_capacity_mAh": [0, 90000],
+                "charge_energy_mWh": [360000, 0],
+                "discharge_energy_mWh": [0, 180000],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        mm = _make_mmap(self.SENTINEL + data)
+
+        df = nda._read_nda_14(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "charge_capacity_mAh", [0.5, 0.0])
+        _assert_col(df, "discharge_capacity_mAh", [0.0, 0.25])
+        _assert_col(df, "charge_energy_mWh", [1.0, 0.0])
+        _assert_col(df, "discharge_energy_mWh", [0.0, 0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda19:
+    """NdaData19 (file version 19): no range field, split charge/discharge in mA*s (/3600)."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad0", "V3"),
+        ("_pad0b", "V4"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u2"),
+        ("step_type", "<u1"),
+        ("_pad1", "V1"),
+        ("_pad2", "V1"),
+        ("_pad3", "V3"),
+        ("step_time_s", "<u4"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad4", "V8"),
+        ("charge_capacity_mAh", "<i4"),
+        ("discharge_capacity_mAh", "<i4"),
+        ("charge_energy_mWh", "<i4"),
+        ("discharge_energy_mWh", "<i4"),
+        ("unix_time_s", "<u4"),
+        ("_pad5", "V4"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85, "cycle_count": 0}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10, 20],
+                "voltage_V": [36000, 35000],
+                "current_mA": [200000, -150000],
+                "charge_capacity_mAh": [1800, 0],
+                "discharge_capacity_mAh": [0, 900],
+                "charge_energy_mWh": [3600, 0],
+                "discharge_energy_mWh": [0, 1800],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=64, main_begin=68)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_19(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "charge_capacity_mAh", [0.5, 0.0])
+        _assert_col(df, "discharge_capacity_mAh", [0.0, 0.25])
+        _assert_col(df, "charge_energy_mWh", [1.0, 0.0])
+        _assert_col(df, "discharge_energy_mWh", [0.0, 0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda25:
+    """NdaData25 (file versions 25, 27): range multiplier, signed net capacity/energy, header offset 32."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad0", "V1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u2"),
+        ("step_type", "<u1"),
+        ("step_time_s", "<u8"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad1", "V8"),
+        ("capacity_mAh", "<i8"),
+        ("energy_mWh", "<i8"),
+        ("unix_time_s", "<u8"),
+        ("range", "<i4"),
+        ("_pad2", "V1"),
+        ("_pad3", "V4"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85, "cycle_count": 0, "range": 100}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10000, 20000],
+                "voltage_V": [36000, 35000],
+                "current_mA": [20000, -15000],
+                "capacity_mAh": [180000, 90000],
+                "energy_mWh": [360000, 180000],
+                "unix_time_s": [1700000000, 1700000010],
+            },
+        )
+        header = _header_offset_preamble(pos_offset=32, main_begin=36)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_25(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "energy_mWh", [1.0, -0.5])
+        _assert_col(df, "unix_time_s", [1700000000, 1700000010])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda29:
+    """NdaData29 (file versions 26, 28, 29): magic-byte header (identifier=85 itself), Y/M/D/h/m/s timestamp."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad1", "V1"),
+        ("index", "<u4"),
+        ("cycle_count", "<u4"),
+        ("step_index", "<u2"),
+        ("step_type", "<u1"),
+        ("step_count", "<u1"),
+        ("step_time_s", "<u8"),
+        ("voltage_V", "<i4"),
+        ("current_mA", "<i4"),
+        ("_pad3", "V8"),
+        ("charge_capacity_mAh", "<i8"),
+        ("discharge_capacity_mAh", "<i8"),
+        ("charge_energy_mWh", "<i8"),
+        ("discharge_energy_mWh", "<i8"),
+        ("Y", "<u2"),
+        ("M", "<u1"),
+        ("D", "<u1"),
+        ("h", "<u1"),
+        ("m", "<u1"),
+        ("s", "<u1"),
+        ("_pad4", "V1"),
+        ("range", "<i4"),
+        ("_pad5", "V4"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {
+        "identifier": 85,  # doubles as the magic-byte header search target
+        "cycle_count": 0,
+        "range": 100,
+        "Y": 2024,
+        "M": 1,
+        "D": 15,
+        "h": 10,
+        "m": 30,
+    }
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_count": [1, 2],
+                "step_time_s": [10000, 20000],
+                "voltage_V": [36000, 35000],
+                "current_mA": [20000, -15000],
+                "charge_capacity_mAh": [180000, 0],
+                "discharge_capacity_mAh": [0, 90000],
+                "charge_energy_mWh": [360000, 0],
+                "discharge_energy_mWh": [0, 180000],
+                "s": [0, 10],
+            },
+        )
+        mm = _make_mmap(data)
+
+        df = nda._read_nda_29(mm)
+
+        expected_unix_a = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc).timestamp()
+        expected_unix_b = datetime(2024, 1, 15, 10, 30, 10, tzinfo=timezone.utc).timestamp()
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "charge_capacity_mAh", [0.5, 0.0])
+        _assert_col(df, "discharge_capacity_mAh", [0.0, 0.25])
+        _assert_col(df, "charge_energy_mWh", [1.0, 0.0])
+        _assert_col(df, "discharge_energy_mWh", [0.0, 0.5])
+        _assert_col(df, "unix_time_s", [expected_unix_a, expected_unix_b], abs_tol=1.0)
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda129:
+    """DFDATA_9021 (file version 129, deprecated by Neware): 64-bit header offset 82, direct floats."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u1"),
+        ("_pad0", "V5"),
+        ("_pad0b", "V2"),
+        ("_pad0c", "V4"),
+        ("index", "<u4"),
+        ("_pad0d", "V4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("_pad1", "V1"),
+        ("_pad2", "V1"),
+        ("_pad3", "V4"),
+        ("step_time_s", "<u4"),  # Time64.dwS (seconds)
+        ("step_time_ns", "<u4"),  # Time64.dwNS (nanoseconds)
+        ("voltage_V", "<f4"),
+        ("current_mA", "<f4"),
+        ("_pad5", "V8"),
+        ("charge_capacity_mAh", "<f4"),
+        ("charge_energy_mWh", "<f4"),
+        ("discharge_capacity_mAh", "<f4"),
+        ("discharge_energy_mWh", "<f4"),
+        ("unix_time_s", "<u8"),
+        ("_pad6", "V12"),
+    ]
+    DEFAULTS: ClassVar[dict[str, float]] = {}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values.
+
+        voltage/current/capacity/energy are already floats here (V, mA, mA*s,
+        mW*s), unlike the integer-encoded older structs.
+        """
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "identifier": [85, 0],  # exercise the "0 or 85" mask
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10, 20],
+                "step_time_ns": [500_000_000, 250_000_000],  # exercises Time64 dwS+dwNS combination
+                "voltage_V": [3.6, 3.5],
+                "current_mA": [200.0, -150.0],
+                "charge_capacity_mAh": [1800.0, 0.0],
+                "charge_energy_mWh": [3600.0, 0.0],
+                "discharge_capacity_mAh": [0.0, 900.0],
+                "discharge_energy_mWh": [0.0, 1800.0],
+                "unix_time_s": [1_700_000_000_000_000, 1_700_000_010_000_000],  # microseconds
+            },
+        )
+        header = _header_offset_preamble(pos_offset=82, main_begin=90, pos64=True)
+        mm = _make_mmap(header + data)
+
+        df = nda._read_nda_129(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.5, 20.25])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "charge_capacity_mAh", [0.5, 0.0])
+        _assert_col(df, "charge_energy_mWh", [1.0, 0.0])
+        _assert_col(df, "discharge_capacity_mAh", [0.0, 0.25])
+        _assert_col(df, "discharge_energy_mWh", [0.0, 0.5])
+        _assert_col(df, "unix_time_s", [1700000000.0, 1700000010.0])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda13090:
+    """NDA 130, BTS9.0 sub-format: magic-byte header search, raw floats already signed."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("_pad1", "V4"),
+        ("identifier", "<u1"),
+        ("_pad2", "V4"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("_pad3", "V5"),
+        ("index", "<u4"),
+        ("_pad4", "V8"),
+        ("step_time_s", "<u8"),
+        ("voltage_V", "<f4"),
+        ("current_mA", "<f4"),
+        ("_pad5", "V16"),
+        ("capacity_mAh", "<f4"),
+        ("energy_mWh", "<f4"),
+        ("unix_time_s", "<u8"),
+        ("_pad6", "V12"),
+    ]
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85}
+    MAGIC: ClassVar[bytes] = b"\x12\x50\x00\x07\x55\x81\x01\x06"
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values.
+
+        Unlike the integer structs, sign lives directly in the raw float here
+        (no separate current-sign multiplication downstream).
+        """
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "index": [1, 2],
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "step_time_s": [10_000_000, 20_000_000],  # microseconds
+                "voltage_V": [3.6, 3.5],
+                "current_mA": [200.0, -150.0],
+                "capacity_mAh": [1800.0, -900.0],
+                "energy_mWh": [3600.0, -1800.0],
+                "unix_time_s": [1_700_000_000_000_000, 1_700_000_010_000_000],
+            },
+        )
+        # Splice in the fixed magic bytes the reader searches for - the real
+        # pad1/identifier/pad2 bytes it expects at the very start of the data
+        # section, not reproducible via generic zero-filled padding.
+        data = self.MAGIC + data[len(self.MAGIC) :]
+        mm = _make_mmap(data)
+
+        df = nda._read_nda_130_90(mm)
+
+        _assert_col(df, "index", [1, 2])
+        _assert_col(df, "step_time_s", [10.0, 20.0])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "capacity_mAh", [0.5, -0.25])
+        _assert_col(df, "energy_mWh", [1.0, -0.5])
+        _assert_col(df, "unix_time_s", [1700000000.0, 1700000010.0])
+        _assert_col(df, "step_count", [1, 2])
+
+
+class TestReadNda13091:
+    """NDA 130, BTS9.1 sub-format: fixed offset 1024, self-describing record length."""
+
+    LAYOUT: ClassVar[list[tuple[str, str]]] = [
+        ("identifier", "<u2"),
+        ("step_index", "<u1"),
+        ("step_type", "<u1"),
+        ("_pad2", "V4"),
+        ("index", "<u4"),
+        ("total_time_s", "<u4"),
+        ("time_ns", "<u4"),
+        ("current_mA", "<f4"),
+        ("voltage_V", "<f4"),
+        ("capacity_mAs", "<f4"),
+        ("energy_mWs", "<f4"),
+        ("cycle_count", "<u4"),
+        ("_pad3", "V4"),
+        ("unix_time_s", "<u4"),
+        ("uts_ns", "<u4"),
+    ]
+    RECORD_LEN = 52  # base layout size - stays under the 56-byte aux-temp threshold
+    IDENTIFIER = 7  # arbitrary 2-byte marker; other field values below avoid reproducing it
+    DEFAULTS: ClassVar[dict[str, int]] = {"identifier": IDENTIFIER, "time_ns": 0, "cycle_count": 0, "uts_ns": 0}
+
+    def test_decodes_expected_values(self) -> None:
+        """Pack synthetic records and check every decoded column against hand-computed values."""
+        data = _build_rows(
+            self.LAYOUT,
+            self.DEFAULTS,
+            columns={
+                "step_index": [1, 2],
+                "step_type": [1, 2],
+                "index": [5, 6],
+                "total_time_s": [10, 20],
+                "current_mA": [200.0, -150.0],
+                "voltage_V": [3.6, 3.5],
+                "capacity_mAs": [1800.0, -900.0],
+                "energy_mWs": [3600.0, -1800.0],
+                "unix_time_s": [1_700_000_000, 1_700_000_010],
+            },
+        )
+        rec_a, rec_b = data[: self.RECORD_LEN], data[self.RECORD_LEN :]
+        assert len(rec_a) == self.RECORD_LEN
+        assert len(rec_b) == self.RECORD_LEN
+        buf = bytearray(1024) + bytearray(rec_a) + bytearray(rec_b)
+        mm = _make_mmap(bytes(buf))
+
+        # Pre-check: the reader infers record_len by re-finding the 2-byte
+        # identifier starting at offset 1026. Confirm our synthetic bytes
+        # don't produce a spurious earlier match before trusting the result.
+        expected_second_record_pos = 1024 + self.RECORD_LEN
+        assert mm.find(mm[1024:1026], 1026) == expected_second_record_pos
+
+        df = nda._read_nda_130_91(mm)
+
+        _assert_col(df, "index", [5, 6])
+        _assert_col(df, "voltage_V", [3.6, 3.5])
+        _assert_col(df, "current_mA", [200.0, -150.0])
+        _assert_col(df, "charge_capacity_mAh", [0.5, 0.0])
+        _assert_col(df, "discharge_capacity_mAh", [0.0, 0.25])
+        _assert_col(df, "charge_energy_mWh", [1.0, 0.0])
+        _assert_col(df, "discharge_energy_mWh", [0.0, 0.5])
+        _assert_col(df, "unix_time_s", [1700000000.0, 1700000010.0])
+        _assert_col(df, "total_time_s", [10.0, 20.0])
+        _assert_col(df, "step_count", [1, 2])

--- a/tests/test_synthetic_nda.py
+++ b/tests/test_synthetic_nda.py
@@ -12,6 +12,7 @@ newly-added structs are currently best guesses, not confirmed with real data.
 
 import mmap
 import struct
+import warnings
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from typing import ClassVar
@@ -1082,3 +1083,65 @@ class TestReadNda13091:
         _assert_col(df, "unix_time_s", [1700000000.0, 1700000010.0])
         _assert_col(df, "total_time_s", [10.0, 20.0])
         _assert_col(df, "step_count", [1, 2])
+
+
+class TestUnverifiedFormatWarning:
+    """UnverifiedFormatWarning fires for unconfirmed nda_versions, not for confirmed ones.
+
+    Builds full "NEWARE"-prefixed buffers and reads them through nda._read_nda, where the
+    warning fires.
+    """
+
+    def test_warns_for_unverified_version(self) -> None:
+        """nda_version 1 (no real data) emits UnverifiedFormatWarning."""
+        header = bytearray(_header_offset_preamble(pos_offset=32, main_begin=36))
+        header[0:6] = b"NEWARE"
+        header[14] = 1  # nda_version
+        record = _build_rows(
+            TestReadNda1.LAYOUT,
+            TestReadNda1.DEFAULTS,
+            columns={
+                "index": [1],
+                "step_index": [1],
+                "step_type": [1],
+                "step_time_s": [10],
+                "voltage_V": [36000],
+                "current_mA": [200000],
+                "capacity_mAh": [1800000],
+            },
+        )
+        mm = _make_mmap(bytes(header) + record)
+
+        with pytest.warns(nda.UnverifiedFormatWarning, match="nda_version 1 "):
+            df = nda._read_nda(mm)
+
+        assert len(df) == 1
+
+    def test_no_warning_for_confirmed_version(self) -> None:
+        """nda_version 8 (has real data) emits no UnverifiedFormatWarning."""
+        header = bytearray(15)
+        header[0:6] = b"NEWARE"
+        header[14] = 8  # nda_version
+        record = _build_rows(
+            TestReadNda5.LAYOUT,
+            TestReadNda5.DEFAULTS,
+            columns={
+                "index": [1],
+                "step_index": [1],
+                "step_type": [1],
+                "step_time_s": [10],
+                "voltage_V": [36000],
+                "current_mA": [200000],
+                "capacity_mAh": [1800000],
+                "energy_mWh": [3600000],
+                "unix_time_s": [1700000000],
+            },
+        )
+        mm = _make_mmap(bytes(header) + TestReadNda5.SENTINEL + record)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            df = nda._read_nda(mm)
+
+        assert not any(issubclass(w.category, nda.UnverifiedFormatWarning) for w in caught)
+        assert len(df) == 1


### PR DESCRIPTION
Adds read support for all known nda versions.

Many file versions use the same reader, e.g. the existing _read_nda_8 covers file versions 5, 6, 7, 8.

Some versions are new, with best guesses and only synthetic data to test. They are probably unreliable and raise a warning on usage. We still need real data for these.