### PR TITLE
Go slightly faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Python and command-line tool to read Neware .nda and .ndax files fast.
 
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/6c6db9a1-e36d-4105-b953-306bba6c916d" width="500" align="center" alt="Aurora cycler manager">
+  <img src="https://github.com/user-attachments/assets/0ac3e5dd-1905-4c4b-937e-4e4663c866d9" width="500" align="center">
 </p>
 <p align="center">
   Time to convert a ~100 MB, 1.3-million-row .ndax file to .csv. Best of three runs.<br>1) Cold start from command-line interface, including module imports.<br>2) Processing time only, without UI navigation.

--- a/fastnda/__init__.py
+++ b/fastnda/__init__.py
@@ -1,9 +1,13 @@
 """Public API."""
 
-from fastnda.btsda import btsda_csv_to_parquet
-from fastnda.dicts import step_type_map
+from typing import TYPE_CHECKING, Any
+
 from fastnda.main import read, read_metadata
 from fastnda.version import __version__
+
+if TYPE_CHECKING:
+    from fastnda.btsda import btsda_csv_to_parquet
+    from fastnda.dicts import step_type_map
 
 __all__ = [
     "__version__",
@@ -12,3 +16,17 @@ __all__ = [
     "read_metadata",
     "step_type_map",
 ]
+
+
+def __getattr__(name: str) -> Any:  # noqa: ANN401
+    """Lazy imports so `import fastnda` doesn't pull in polars/numpy."""
+    if name == "btsda_csv_to_parquet":
+        from fastnda.btsda import btsda_csv_to_parquet  # noqa: PLC0415
+
+        return btsda_csv_to_parquet
+    if name == "step_type_map":
+        from fastnda.dicts import step_type_map  # noqa: PLC0415
+
+        return step_type_map
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/fastnda/_ndc/ndc_utils.py
+++ b/fastnda/_ndc/ndc_utils.py
@@ -55,9 +55,10 @@ def bytes_to_df(
 
     # Slice the data
     data_end_ind = data_start_ind + dtype.itemsize * rows_per_record
-    data = np.ascontiguousarray(arr[:, data_start_ind:data_end_ind]).view(dtype_no_pad).ravel()
+    sliced = arr[:, data_start_ind:data_end_ind].view(dtype_no_pad)
+    columns = {name: np.ascontiguousarray(sliced[name]).ravel() for name in dtype_no_pad.names}
 
-    df = pl.DataFrame(data)
+    df = pl.DataFrame(columns)
 
     if not use_bitmask:
         return df.filter(pl.col("index") != 0)

--- a/fastnda/nda.py
+++ b/fastnda/nda.py
@@ -135,8 +135,9 @@ def _get_arr_from_nda(
     """Read an nda file."""
     header_idx = _find_header(mm, header)
     num_records = (len(mm) - header_idx) // record_len
-    end = header_idx + num_records * record_len
-    return np.frombuffer(mm[header_idx:end], dtype=np.uint8).reshape((num_records, record_len))
+    return np.frombuffer(mm, dtype=np.uint8, count=num_records * record_len, offset=header_idx).reshape(
+        (num_records, record_len)
+    )
 
 
 def _view_arr(

--- a/tests/test_btsda.py
+++ b/tests/test_btsda.py
@@ -6,7 +6,8 @@ from tempfile import TemporaryDirectory
 import polars as pl
 from polars.testing import assert_frame_equal
 
-from fastnda.btsda import _time_str_to_float, btsda_csv_to_parquet
+from fastnda import btsda_csv_to_parquet
+from fastnda.btsda import _time_str_to_float
 
 
 class TestBTSDA:

--- a/tests/test_no_isal.py
+++ b/tests/test_no_isal.py
@@ -12,10 +12,10 @@ import fastnda
 @pytest.fixture
 def fastnda_no_isal(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """Simulate isal not being installed."""
-    # Remove fastnda + isal from cache
+    # Remove fastnda + isal from cache via monkeypatch
     to_remove = [key for key in sys.modules if key in {"isal", "fastnda"} or key.startswith(("isal.", "fastnda."))]
     for module in to_remove:
-        sys.modules.pop(module, None)
+        monkeypatch.delitem(sys.modules, module, raising=False)
 
     # Remove isal from sys.modules
     monkeypatch.setitem(sys.modules, "isal", None)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,7 @@ import mmap
 
 import polars as pl
 
+from fastnda import step_type_map  # noqa: F401, ensure import works
 from fastnda.nda import _merge_aux, _read_nda_130_91
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3,9 +3,18 @@
 import mmap
 
 import polars as pl
+import pytest
 
-from fastnda import step_type_map  # noqa: F401, ensure import works
+import fastnda
 from fastnda.nda import _merge_aux, _read_nda_130_91
+
+
+def test_lazy_imports() -> None:
+    """Lazy imports resolve known names and rejects unknown ones."""
+    assert fastnda.step_type_map is fastnda.dicts.step_type_map
+    assert fastnda.btsda_csv_to_parquet is fastnda.btsda.btsda_csv_to_parquet
+    with pytest.raises(AttributeError, match="no attribute 'foo'"):
+        fastnda.foo  # noqa: B018
 
 
 def test_nda_aux_merge() -> None:


### PR DESCRIPTION
Small changes to NDA and NDC readers that result in fewer copies made.

Lazy imports in __init__ so import fastnda does not trigger polars/numpy.