### PR TITLE
Use bins instead of map for range -> multiplier

### DIFF
--- a/fastnda/_ndc/ndc_main.py
+++ b/fastnda/_ndc/ndc_main.py
@@ -8,8 +8,7 @@ import numpy as np
 import polars as pl
 
 from fastnda._ndc.ndc_utils import bytes_to_df
-from fastnda.dicts import MULTIPLIER_MAP
-from fastnda.utils import _count_changes
+from fastnda.utils import _count_changes, _range_to_mult
 
 
 def read_ndc_main_1(buf: bytes) -> pl.DataFrame:
@@ -46,7 +45,7 @@ def read_ndc_main_1(buf: bytes) -> pl.DataFrame:
                 pl.col("cycle_count") + 1,
                 pl.col("step_time_s").cast(pl.Float64) * 1e-3,
                 pl.col("voltage_V").cast(pl.Float32) * 1e-4,
-                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _range_to_mult(pl.col("range")).alias("multiplier"),
                 pl.datetime(pl.col("Y"), pl.col("M"), pl.col("D"), pl.col("h"), pl.col("m"), pl.col("s")).alias(
                     "timestamp"
                 ),
@@ -104,7 +103,7 @@ def read_ndc_main_2(buf: bytes) -> pl.DataFrame:
                 pl.col("cycle_count") + 1,
                 pl.col("step_time_s").cast(pl.Float64) * 1e-3,
                 pl.col("voltage_V").cast(pl.Float32) * 1e-4,
-                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _range_to_mult(pl.col("range")).alias("multiplier"),
                 pl.datetime(pl.col("Y"), pl.col("M"), pl.col("D"), pl.col("h"), pl.col("m"), pl.col("s")).alias(
                     "timestamp"
                 ),
@@ -162,7 +161,7 @@ def read_ndc_main_5(buf: bytes) -> pl.DataFrame:
                 pl.col("cycle_count") + 1,
                 pl.col("step_time_s").cast(pl.Float64) * 1e-3,
                 pl.col("voltage_V").cast(pl.Float32) * 1e-4,
-                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _range_to_mult(pl.col("range")).alias("multiplier"),
                 pl.datetime(pl.col("Y"), pl.col("M"), pl.col("D"), pl.col("h"), pl.col("m"), pl.col("s")).alias(
                     "timestamp"
                 ),

--- a/fastnda/dicts.py
+++ b/fastnda/dicts.py
@@ -81,6 +81,7 @@ DTYPE_MAP: Mapping[str, type[pl.DataType]] = MappingProxyType(
 )
 
 # Current value multiplier based on instrument Range setting
+# Not used any more, utils._range_to_mult() is used instead, left for backwards compatibility
 MULTIPLIER_MAP = MappingProxyType(
     {
         -100000000: 1e1,

--- a/fastnda/dicts.py
+++ b/fastnda/dicts.py
@@ -84,7 +84,7 @@ DTYPE_MAP: Mapping[str, type[pl.DataType]] = MappingProxyType(
 # Not used any more, utils._range_to_mult() is used instead, left for backwards compatibility
 MULTIPLIER_MAP = MappingProxyType(
     {
-        -100000000: 1e1,
+        -100000000: 1e1,  # 1e-6 in _range_to_mult
         -200000: 1e-2,
         -100000: 1e-2,
         -60000: 1e-2,
@@ -108,7 +108,7 @@ MULTIPLIER_MAP = MappingProxyType(
         -5: 1e-5,
         -2: 1e-5,
         -1: 1e-5,
-        0: 0.0,
+        0: 0.0,  # 1e-1 in _range_to_mult
         1: 1e-4,
         2: 1e-4,
         5: 1e-4,

--- a/fastnda/nda.py
+++ b/fastnda/nda.py
@@ -12,8 +12,7 @@ from pathlib import Path
 import numpy as np
 import polars as pl
 
-from fastnda.dicts import MULTIPLIER_MAP
-from fastnda.utils import UnverifiedFormatWarning, _count_changes
+from fastnda.utils import UnverifiedFormatWarning, _count_changes, _range_to_mult
 
 logger = logging.getLogger(__name__)
 
@@ -704,7 +703,7 @@ def _read_nda_11(mm: mmap.mmap) -> pl.DataFrame:
                 pl.col("cycle_count") + 1,
                 pl.col("step_time_s").cast(pl.Float32) / 1000,
                 pl.col("voltage_V").cast(pl.Float32) / 10000,
-                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _range_to_mult(pl.col("range")).alias("multiplier"),
                 _count_changes(pl.col("step_index")).alias("step_count"),
             ]
         )
@@ -756,7 +755,7 @@ def _read_nda_14(mm: mmap.mmap) -> pl.DataFrame:
                 pl.col("cycle_count") + 1,
                 pl.col("step_time_s").cast(pl.Float32) / 1000,
                 pl.col("voltage_V").cast(pl.Float32) / 10000,
-                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _range_to_mult(pl.col("range")).alias("multiplier"),
                 _count_changes(pl.col("step_index")).alias("step_count"),
             ]
         )
@@ -842,7 +841,7 @@ def _read_nda_25(mm: mmap.mmap) -> pl.DataFrame:
                 pl.col("cycle_count") + 1,
                 pl.col("step_time_s").cast(pl.Float32) / 1000,
                 pl.col("voltage_V").cast(pl.Float32) / 10000,
-                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _range_to_mult(pl.col("range")).alias("multiplier"),
                 _count_changes(pl.col("step_index")).alias("step_count"),
             ]
         )
@@ -900,7 +899,7 @@ def _read_nda_29(mm: mmap.mmap) -> pl.DataFrame:
                 pl.col("cycle_count") + 1,
                 pl.col("step_time_s").cast(pl.Float32) / 1000,
                 pl.col("voltage_V").cast(pl.Float32) / 10000,
-                pl.col("range").replace_strict(MULTIPLIER_MAP, return_dtype=pl.Float64).alias("multiplier"),
+                _range_to_mult(pl.col("range")).alias("multiplier"),
                 pl.datetime(pl.col("Y"), pl.col("M"), pl.col("D"), pl.col("h"), pl.col("m"), pl.col("s")).alias(
                     "timestamp"
                 ),

--- a/fastnda/utils.py
+++ b/fastnda/utils.py
@@ -71,5 +71,28 @@ def _id_first_state(df: pl.DataFrame) -> Literal["chg", "dchg"]:
     return "dchg"
 
 
+def _range_to_mult(series: pl.Expr) -> pl.Expr:
+    """Generate multiplier from current range."""
+    a = series.abs()
+    return (
+        pl.when((series == 0) | (series < -2e9)).then(1e-1)
+        .when(series < 0).then(
+            pl.when(a < 10).then(1e-5)
+            .when(a < 100).then(1e-4)
+            .when(a < 1000).then(1e-3)
+            .when(a < 1000000).then(1e-2)
+            .when(a < 10000000).then(1e-8)
+            .when(a < 100000000).then(1e-7)
+            .otherwise(1e-6)
+        )
+        .otherwise(
+            pl.when(a < 10).then(1e-4)
+            .when(a < 100).then(1e-3)
+            .when(a < 1000).then(1e-2)
+            .otherwise(1e-1)
+        )
+    )  # fmt: skip
+
+
 class UnverifiedFormatWarning(UserWarning):
     """Raised when reading an nda_version which hasn't been tested against real data."""

--- a/tests/test_synthetic_nda.py
+++ b/tests/test_synthetic_nda.py
@@ -546,7 +546,7 @@ class TestReadNda11:
         ("range", "<i4"),
         ("_pad2", "V4"),
     ]
-    # range=100 -> multiplier 1e-2 (see fastnda.dicts.MULTIPLIER_MAP)
+    # range=100 -> multiplier 1e-2
     DEFAULTS: ClassVar[dict[str, int]] = {"identifier": 85, "cycle_count": 0, "range": 100}
 
     def test_decodes_expected_values(self) -> None:


### PR DESCRIPTION
Disagrees with previous map on keys `0` and `-1e8` but I can't verify which is correct. I only have ranges `{-100, -2000, -10000, -20000, -30000, -50000}` in test set. Key `0` came from the initial commit, maybe assumed, key `-1e8` from issue 42 in SES repo.